### PR TITLE
Feature Read Time 

### DIFF
--- a/plugins/_readtime.php
+++ b/plugins/_readtime.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ * Plugin Name: Reading Time
+ * Description: Adds estimated reading time to a post custom fields using a simple formula.
+ * Version:     1.0.0
+ * Author:      justingreerbbi
+ * Author URI:  https://wordpress.org
+ * License:     GPL3
+ * License URI: https://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
+
+// Put this here for future
+//load_plugin_textdomain('your-unique-name', false, basename( dirname( __FILE__ ) ) . '/languages' );
+
+/**
+ * HOW THIS WORKS
+ *
+ * Reference https://medium.com/the-story/read-time-and-you-bc2048ab620c#.xmqnie7ga to see how
+ * Medium calculates.
+ *
+ * There is many ways that we could tackle this but the less load will be to calculate
+ * on save of a post.
+ *
+ * CALCULATING FORMULA
+ *
+ * - 275 WPM Roughly
+ * - Each Image is ~12 seconds. I am not sure we need 12 seconds for any image but we will use
+ * this as a starting point.
+ * - if there are 10 images or more, each image after 9 will add 3 seconds.
+ *
+ * - Unknowns are snippets, pre tags (assuming) and if there is video. Is it read time or "Do time"?
+ */
+
+/**
+ * [hh_calulate_post_readtime description]
+ * @return [type] [description]
+ */
+function hh_calulate_and_update_post_readtime( $post_id, $post, $update ) {
+
+  // If this is just a revision, don't send the email.
+  if ( wp_is_post_revision( $post_id ) )
+    return;
+
+  // Only run for certain CPT's. We could just statically check but lets think scalability and maybe 
+  // even feature plugin's for core one day!
+  $calculate_for_posts = apply_filters('read_time_types', array('post') );
+  if( !in_array($post->post_type, $calculate_for_posts) )
+    return;
+
+  // Average words per minute integer. As always, we should keep it filterable.
+  // @uses filter read_time_average
+  $average_word_per_minute = apply_filters('read_time_average', 300);
+
+  // We can extend later and make an object that can be edited later for configuration.  
+  $word_count = str_word_count(wp_strip_all_tags( $post->post_content ) );
+
+  // This could be simpler but I wanted to spell it out.
+  // 275 / 60 = Average Words Per Second.
+  // Average Words Per Second / Word Count = Total Number of Seconds in read time.
+  // Total Number of Seconds in read time / 60 = Final Estimated Read Time in Minutes
+  $readtime = round( $word_count / ( $average_word_per_minute / 60 ) );
+
+  // Lets grab the images out of the post content
+  preg_match_all('/(img|src)\=(\"|\')[^\"\'\>]+/i', $post->post_content, $media);
+  if( $image_count = count( $media[0] ) )
+    $readtime = ($image_count*12-$image_count+$readtime);
+
+  //if($image_count >= 10){
+  //  $readtime_adjustment = (10 - $image_count); // subtract this from overall read time
+  //  print_r($readtime_adjustment);
+  // }
+
+  // Update the posts read time
+  update_post_meta( $post_id, '_read_time', $readtime);
+
+  // REMOVE THIS LINE BEFORE PUSHING
+  update_post_meta( $post_id, 'read_time', $readtime);
+}
+add_action( 'save_post', 'hh_calulate_and_update_post_readtime', 10, 3 );

--- a/plugins/_readtime.php
+++ b/plugins/_readtime.php
@@ -15,51 +15,28 @@ defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
 //load_plugin_textdomain('your-unique-name', false, basename( dirname( __FILE__ ) ) . '/languages' );
 
 /**
- * HOW THIS WORKS
- *
- * Reference https://medium.com/the-story/read-time-and-you-bc2048ab620c#.xmqnie7ga to see how
- * Medium calculates.
- *
- * There is many ways that we could tackle this but the less load will be to calculate
- * on save of a post.
- *
- * CALCULATING FORMULA
- *
- * - 275 WPM Roughly
- * - Each Image is ~12 seconds. I am not sure we need 12 seconds for any image but we will use
- * this as a starting point.
- * - if there are 10 images or more, each image after 9 will add 3 seconds.
- *
- * - Unknowns are snippets, pre tags (assuming) and if there is video. Is it read time or "Do time"?
- */
-
-/**
  * [hh_calulate_post_readtime description]
  * @return [type] [description]
  */
 function hh_calulate_and_update_post_readtime( $post_id, $post, $update ) {
 
-  // If this is just a revision, don't send the email.
+  // No post revisions
   if ( wp_is_post_revision( $post_id ) )
     return;
 
-  // Only run for certain CPT's. We could just statically check but lets think scalability and maybe 
-  // even feature plugin's for core one day!
+  // Only run for certain post types. We could just statically check but lets think scalability here
+  // and try to get into core one day!
   $calculate_for_posts = apply_filters('read_time_types', array('post') );
   if( !in_array($post->post_type, $calculate_for_posts) )
     return;
 
   // Average words per minute integer. As always, we should keep it filterable.
-  // @uses filter read_time_average
-  $average_word_per_minute = apply_filters('read_time_average', 300);
+  $average_word_per_minute = apply_filters('read_time_average', 275);
 
-  // We can extend later and make an object that can be edited later for configuration.  
+  // Simple method of grabbing the word count  
   $word_count = str_word_count(wp_strip_all_tags( $post->post_content ) );
 
-  // This could be simpler but I wanted to spell it out.
-  // 275 / 60 = Average Words Per Second.
-  // Average Words Per Second / Word Count = Total Number of Seconds in read time.
-  // Total Number of Seconds in read time / 60 = Final Estimated Read Time in Minutes
+  // Read time is calculated use the formula below/
   $readtime = round( $word_count / ( $average_word_per_minute / 60 ) );
 
   // Lets grab the images out of the post content
@@ -67,15 +44,18 @@ function hh_calulate_and_update_post_readtime( $post_id, $post, $update ) {
   if( $image_count = count( $media[0] ) )
     $readtime = ($image_count*12-$image_count+$readtime);
 
-  //if($image_count >= 10){
-  //  $readtime_adjustment = (10 - $image_count); // subtract this from overall read time
-  //  print_r($readtime_adjustment);
-  // }
-
+  /**
+   * For articles that have more than say 10 images, the formula will overbid
+   * the read time since images hold a high weight. We counter the weight above but the code below 
+   * may be able to add more or a accurate read time with an article count higher then say 10.
+   *
+   * if($image_count >= 10){
+   *   $readtime_adjustment = (10 - $image_count); // subtract this from overall read time
+   *   print_r($readtime_adjustment);
+   * }
+   */
+  
   // Update the posts read time
   update_post_meta( $post_id, '_read_time', $readtime);
-
-  // REMOVE THIS LINE BEFORE PUSHING
-  update_post_meta( $post_id, 'read_time', $readtime);
 }
 add_action( 'save_post', 'hh_calulate_and_update_post_readtime', 10, 3 );

--- a/plugins/_readtime.php
+++ b/plugins/_readtime.php
@@ -11,9 +11,6 @@
 
 defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
 
-// Put this here for future
-//load_plugin_textdomain('your-unique-name', false, basename( dirname( __FILE__ ) ) . '/languages' );
-
 /**
  * [hh_calulate_post_readtime description]
  * @return [type] [description]
@@ -61,13 +58,25 @@ function hh_calulate_and_update_post_readtime( $post_id, $post, $update ) {
 add_action( 'save_post', 'hh_calulate_and_update_post_readtime', 10, 3 );
 
 /**
- * Returns an output of read time for a given post.
- * @param  [type] $post_id [description]
- * @return [type]          [description]
+ * Returns an output of read time for a given post. 
+ *
+ * get_the_read_time can be ran inside the loop or can be called using a post ID.
+ * The function tries to default to the global post if there is not Post ID provided.
+ *
+ * @example 
+ * <?php echo get_the_read_time(); ?>
+ * 
+ * @example
+ * <?php echo get_the_read_time( $post->ID );
+ * 
+ * @param  Int $post_id   Post ID to lookup the read time.
+ * @return String         A formatted string containing a converted read time into minutes.
  */
-function hh_get_post_read_time( $post_id=null ) {
-  if(is_null($post_id))
-    return;
+function get_the_read_time( $post_id=null ) {
+  if( is_null( $post_id ) ) {
+    global $post;
+    $post_id = $post->ID;
+  } 
 
   // Grab the meta field for read time
   $read_time = get_post_meta($post_id, '_read_time', true);
@@ -76,7 +85,7 @@ function hh_get_post_read_time( $post_id=null ) {
   // 
   // Why did we not do this on save? 
   // Seconds can be manipulated easy and are flexible.
-  $converted_readtime = round($readtime/60);
+  $converted_readtime = $read_time == 0 ? '~1' : round( $read_time / 60 );
 
-  return sprintf( esc_html__( 'Read Time: %s Min.', 'helphub' ), $converted_readtime );
+  return sprintf( esc_html__( 'Read Time: %s Min', 'helphub' ), $converted_readtime );
 }

--- a/plugins/_readtime.php
+++ b/plugins/_readtime.php
@@ -59,3 +59,24 @@ function hh_calulate_and_update_post_readtime( $post_id, $post, $update ) {
   update_post_meta( $post_id, '_read_time', $readtime);
 }
 add_action( 'save_post', 'hh_calulate_and_update_post_readtime', 10, 3 );
+
+/**
+ * Returns an output of read time for a given post.
+ * @param  [type] $post_id [description]
+ * @return [type]          [description]
+ */
+function hh_get_post_read_time( $post_id=null ) {
+  if(is_null($post_id))
+    return;
+
+  // Grab the meta field for read time
+  $read_time = get_post_meta($post_id, '_read_time', true);
+
+  // Convert read time from seconds to minutes.
+  // 
+  // Why did we not do this on save? 
+  // Seconds can be manipulated easy and are flexible.
+  $converted_readtime = round($readtime/60);
+
+  return sprintf( esc_html__( 'Read Time: %s Min.', 'helphub' ), $converted_readtime );
+}


### PR DESCRIPTION
Ready for testing. 
The plugin uses the average WPM (words per minute) of 275. Images add 12 seconds and gracefully depreciate in weight value the more images there there are in the content. Read Time is updated on save to a hidden custom field in the format of seconds.

**Filters**:
- read_time_types - (Array) Can be extended to all types if needed but default to only posts.
- read_time_average - (Int) Holds the WPM integer so that it can be changed externally if needed. Defaults to 275.

**Usage**:
`<?php echo get_the_read_time(); ?>`
or
`<?php echo get_the_read_time($post->ID); ?>`
