### PR TITLE
Adds Post Type, Taxonomy and Meta Field controls

### DIFF
--- a/plugins/helphub-post-types/assets/css/admin.css
+++ b/plugins/helphub-post-types/assets/css/admin.css
@@ -1,0 +1,8 @@
+.post-type.edit-php table.wp-list-table .column-image {
+  width: 120px;
+  text-align: center; }
+  .post-type.edit-php table.wp-list-table .column-image img {
+    width: 60px;
+    height: auto; }
+
+

--- a/plugins/helphub-post-types/assets/js/admin.js
+++ b/plugins/helphub-post-types/assets/js/admin.js
@@ -1,0 +1,48 @@
+jQuery(document).ready(function($){
+
+
+	// Instantiates the variable that holds the media library frame.
+	var gallery_data_frame;
+
+	// Runs when the image button is clicked.
+	jQuery( '.postbox' ).on( 'click', '.helphub-upload', function( event ) {
+
+		// Prevents the default action from occuring.
+		event.preventDefault();
+
+		// store button object
+		$button = $(this);
+
+		// If the frame already exists, re-open it.
+		if ( gallery_data_frame ) {
+			gallery_data_frame.open();
+			return;
+		}
+
+		title = $button.data( 'title' ) ? $button.data( 'title' ) : helphub_admin.default_title;
+		button = $button.data( 'button' ) ? $button.data( 'button' ) : helphub_admin.default_button;
+		library = $button.data( 'library' ) ? $button.data( 'library' ) : '';
+
+		// Sets up the media library frame
+		gallery_data_frame = wp.media.frames.gallery_data_frame = wp.media({
+			title: title,
+			button: { text: button },
+			library: { type: library }
+		});
+
+		// Runs when an image is selected.
+		gallery_data_frame.on( 'select', function(){
+
+			// Grabs the attachment selection and creates a JSON representation of the model.
+			var media_attachment = gallery_data_frame.state().get( 'selection' ).first().toJSON();
+
+			// Sends the attachment URL to our custom image input field.
+			$button.prev( 'input.helphub-upload-field' ).val( media_attachment.url );
+
+		});
+
+		// Opens the media library frame.
+		gallery_data_frame.open();
+	});
+
+});

--- a/plugins/helphub-post-types/assets/js/gallery.js
+++ b/plugins/helphub-post-types/assets/js/gallery.js
@@ -1,0 +1,107 @@
+/**
+ * Created by User on 29/12/2015.
+ */
+jQuery(document).ready(function($){
+    // Uploading files
+    var helphub_gallery_frame;
+    var $gallery_container 	= $( '#helphub_images_container')
+    var $image_gallery_ids 	= $( '#helphub_image_gallery' );
+    var $gallery_images 	= $gallery_container.find( 'ul.product_images' );
+    var $gallery_ul			= $gallery_container.find( 'ul li.image' );
+
+    jQuery( '.add_helphub_images' ).on( 'click', 'a', function( event ) {
+
+        var $el 			= $(this);
+        var attachment_ids 	= $image_gallery_ids.val();
+
+        event.preventDefault();
+        //event.stopPropagation();
+        //event.stopImmediatePropagation();
+
+        // If the media frame already exists, reopen it.
+        if ( helphub_gallery_frame ) {
+            helphub_gallery_frame.open();
+            return;
+        }
+
+        // Create the media frame.
+        helphub_gallery_frame = wp.media.frames.downloadable_file = wp.media({
+            // Set the title of the modal.
+            title: helphub_helphub_gallery.gallery_title,
+            button: {
+                text: helphub_helphub_gallery.gallery_button,
+            },
+            multiple: true
+        });
+
+        // When an image is selected, run a callback.
+        helphub_gallery_frame.on( 'select', function() {
+
+            var selection = helphub_gallery_frame.state().get( 'selection' );
+
+            selection.map( function( attachment ) {
+
+                attachment = attachment.toJSON();
+
+                if ( attachment.id ) {
+                    attachment_ids = attachment_ids ? attachment_ids + "," + attachment.id : attachment.id;
+
+                    $gallery_images.append('\
+                            <li class="image" data-attachment_id="' + attachment.id + '">\
+                                <img src="' + attachment.sizes.thumbnail.url + '" />\
+                                    <ul class="actions">\
+                                        <li><a href="#" class="delete" title="'+ helphub_helphub_gallery.delete_image +'">&times;</a></li>\
+                                    </ul>\
+                                </li>');
+                }
+
+            } );
+
+            $image_gallery_ids.val( attachment_ids );
+        });
+
+        // Finally, open the modal.
+        helphub_gallery_frame.open();
+    });
+
+    // Image ordering
+    $gallery_images.sortable({
+        items: 'li.image',
+        cursor: 'move',
+        scrollSensitivity:40,
+        forcePlaceholderSize: true,
+        forceHelperSize: false,
+        helper: 'clone',
+        opacity: 0.65,
+        placeholder: 'helphub-metabox-sortable-placeholder',
+        start:function(event,ui){
+            ui.item.css( 'background-color','#f6f6f6' );
+        },
+        stop:function(event,ui){
+            ui.item.removeAttr( 'style' );
+        },
+        update: function(event, ui) {
+            var attachment_ids = '';
+            $gallery_container.find( 'ul li.image' ).css( 'cursor','default' ).each(function() {
+                var attachment_id = jQuery(this).attr( 'data-attachment_id' );
+                attachment_ids = attachment_ids + attachment_id + ',';
+            });
+            $image_gallery_ids.val( attachment_ids );
+        }
+    });
+    // Remove images
+    $gallery_container.on( 'click', 'a.delete', function() {
+        $(this).closest( 'li.image' ).remove();
+
+        var attachment_ids = '';
+
+        $gallery_ul.css( 'cursor','default' ).each(function() {
+            var attachment_id = jQuery(this).attr( 'data-attachment_id' );
+            attachment_ids = attachment_ids + attachment_id + ',';
+        });
+
+        $image_gallery_ids.val( attachment_ids );
+
+        return false;
+    } );
+} );

--- a/plugins/helphub-post-types/classes/class-helphub-post-types-post-type.php
+++ b/plugins/helphub-post-types/classes/class-helphub-post-types-post-type.php
@@ -1,0 +1,588 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly.
+
+/**
+ * Helphub Post Types, Post Type Class
+ *
+ * All functionality pertaining to post types in Helphub Post Types.
+ *
+ * @package WordPress
+ * @subpackage HelpHub_Post_Types
+ * @category Plugin
+ * @author Jon Ang
+ * @since 1.0.0
+ */
+class HelpHub_Post_Types_Post_Type {
+	/**
+	 * The post type token.
+	 * @access public
+	 * @since  1.0.0
+	 * @var    string
+	 */
+	public $post_type;
+
+	/**
+	 * The post type singular label.
+	 * @access public
+	 * @since  1.0.0
+	 * @var    string
+	 */
+	public $singular;
+
+	/**
+	 * The post type plural label.
+	 * @access public
+	 * @since  1.0.0
+	 * @var    string
+	 */
+	public $plural;
+
+	/**
+	 * The post type args.
+	 * @access public
+	 * @since  1.0.0
+	 * @var    array
+	 */
+	public $args;
+
+	/**
+	 * The taxonomies for this post type.
+	 * @access public
+	 * @since  1.0.0
+	 * @var    array
+	 */
+	public $taxonomies;
+
+	/**
+	 * Constructor function.
+	 * @access public
+	 * @since 1.0.0
+	 */
+	public function __construct( $post_type = 'thing', $singular = '', $plural = '', $args = array(), $taxonomies = array() ) {
+		$this->post_type = $post_type;
+		$this->singular = $singular;
+		$this->plural = $plural;
+		$this->args = $args;
+		$this->taxonomies = $taxonomies;
+
+		add_action( 'init', array( $this, 'register_post_type' ) );
+		add_action( 'init', array( $this, 'register_taxonomy' ) );
+
+		if ( is_admin() ) {
+			global $pagenow;
+
+			add_action( 'admin_menu', array( $this, 'meta_box_setup' ), 20 );
+			add_action( 'save_post', array( $this, 'meta_box_save' ) );
+			add_filter( 'enter_title_here', array( $this, 'enter_title_here' ) );
+			add_filter( 'post_updated_messages', array( $this, 'updated_messages' ) );
+
+			if ( $pagenow == 'edit.php' && isset( $_GET['post_type'] ) && esc_attr( $_GET['post_type'] ) == $this->post_type ) {
+				add_filter( 'manage_edit-' . $this->post_type . '_columns', array( $this, 'register_custom_column_headings' ), 10, 1 );
+				add_action( 'manage_posts_custom_column', array( $this, 'register_custom_columns' ), 10, 2 );
+			}
+		}
+		add_action( 'admin_init', array( $this, 'add_menu_order' ) );
+		add_action( 'after_setup_theme', array( $this, 'ensure_post_thumbnails_support' ) );
+		add_action( 'after_setup_theme', array( $this, 'register_image_sizes' ) );
+	} // End __construct()
+
+	/**
+	 * Register the post type.
+	 * @access public
+	 * @return void
+	 */
+	public function register_post_type () {
+
+		if ( post_type_exists( $this->post_type ) ):
+			return;
+		endif;
+
+		$labels = array(
+			'name' => sprintf( _x( '%s', 'post type general name', 'helphub' ), $this->plural ),
+			'singular_name' => sprintf( _x( '%s', 'post type singular name', 'helphub' ), $this->singular ),
+			'add_new' => _x( 'Add New', $this->post_type, 'helphub' ),
+			'add_new_item' => sprintf( __( 'Add New %s', 'helphub' ), $this->singular ),
+			'edit_item' => sprintf( __( 'Edit %s', 'helphub' ), $this->singular ),
+			'new_item' => sprintf( __( 'New %s', 'helphub' ), $this->singular ),
+			'all_items' => sprintf( __( 'All %s', 'helphub' ), $this->plural ),
+			'view_item' => sprintf( __( 'View %s', 'helphub' ), $this->singular ),
+			'search_items' => sprintf( __( 'Search %a', 'helphub' ), $this->plural ),
+			'not_found' => sprintf( __( 'No %s Found', 'helphub' ), $this->plural ),
+			'not_found_in_trash' => sprintf( __( 'No %s Found In Trash', 'helphub' ), $this->plural ),
+			'parent_item_colon' => '',
+			'menu_name' => $this->plural,
+		);
+
+		$single_slug = apply_filters( 'helphub_single_slug', _x( sanitize_title_with_dashes( $this->singular ), 'single post url slug', 'helphub' ) );
+		$archive_slug = apply_filters( 'helphub_archive_slug', _x( sanitize_title_with_dashes( $this->plural ), 'post archive url slug', 'helphub' ) );
+
+		$defaults = array(
+			'labels' => $labels,
+			'public' => true,
+			'publicly_queryable' => true,
+			'show_ui' => true,
+			'show_in_menu' => true,
+			'query_var' => true,
+			'rewrite' => array( 'slug' => $single_slug ),
+			'capability_type' => 'post',
+			'has_archive' => $archive_slug,
+			'hierarchical' => false,
+			'supports' => array( 'title', 'editor', 'excerpt', 'thumbnail', 'page-attributes' ),
+			'menu_position' => 5,
+			'menu_icon' => 'dashicons-smiley',
+		);
+
+		$args = wp_parse_args( $this->args, $defaults );
+
+		register_post_type( $this->post_type, $args );
+	} // End register_post_type()
+
+	/**
+	 * Register the post-type taxonomy.
+	 * @access public
+	 * @since  1.3.0
+	 * @return void
+	 */
+	public function register_taxonomy () {
+		foreach ( $this->taxonomies as $taxonomy ):
+			$taxonomy = new HelpHub_Post_Types_Taxonomy( esc_attr( $this->post_type ), $taxonomy, '', '', array() ); // Leave arguments empty, to use the default arguments.
+			$taxonomy->register();
+		endforeach;
+	} // End register_taxonomy()
+
+	/**
+	 * Add custom columns for the "manage" screen of this post type.
+	 * @access public
+	 * @param string $column_name
+	 * @param int $id
+	 * @since  1.0.0
+	 * @return void
+	 */
+	public function register_custom_columns ( $column_name, $id ) {
+		global $post;
+
+		switch ( $column_name ) {
+			case 'image':
+				echo $this->get_image( $id, 40 );
+			break;
+
+			default:
+			break;
+		}
+	} // End register_custom_columns()
+
+	/**
+	 * Add custom column headings for the "manage" screen of this post type.
+	 * @access public
+	 * @param array $defaults
+	 * @since  1.0.0
+	 * @return array $defaults
+	 */
+	public function register_custom_column_headings ( $defaults ) {
+		$new_columns = array( 'image' => __( 'Image', 'helphub' ) );
+
+		$last_item = array();
+
+		if ( isset( $defaults['date'] ) ) { unset( $defaults['date'] ); }
+
+		if ( count( $defaults ) > 2 ) {
+			$last_item = array_slice( $defaults, -1 );
+
+			array_pop( $defaults );
+		}
+		$defaults = array_merge( $defaults, $new_columns );
+
+		if ( is_array( $last_item ) && 0 < count( $last_item ) ) {
+			foreach ( $last_item as $k => $v ) {
+				$defaults[$k] = $v;
+				break;
+			}
+		}
+
+		return $defaults;
+	} // End register_custom_column_headings()
+
+	/**
+	 * Update messages for the post type admin.
+	 * @since  1.0.0
+	 * @param  array $messages Array of messages for all post types.
+	 * @return array           Modified array.
+	 */
+	public function updated_messages ( $messages ) {
+		global $post, $post_ID;
+
+		$messages[$this->post_type] = array(
+			0 => '', // Unused. Messages start at index 1.
+			1 => sprintf( __( '%3$s updated. %sView %4$s%s', 'helphub' ), '<a href="' . esc_url( get_permalink( $post_ID ) ) . '">', '</a>', $this->singular, strtolower( $this->singular ) ),
+			2 => __( 'Custom field updated.', 'helphub' ),
+			3 => __( 'Custom field deleted.', 'helphub' ),
+			4 => sprintf( __( '%s updated.', 'helphub' ), $this->singular ),
+			/* translators: %s: date and time of the revision */
+			5 => isset($_GET['revision']) ? sprintf( __( '%s restored to revision from %s', 'helphub' ), $this->singular, wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
+			6 => sprintf( __( '%1$s published. %3$sView %2$s%4$s', 'helphub' ), $this->singular, strtolower( $this->singular ), '<a href="' . esc_url( get_permalink( $post_ID ) ) . '">', '</a>' ),
+			7 => sprintf( __( '%s saved.', 'helphub' ), $this->singular ),
+			8 => sprintf( __( '%s submitted. %sPreview %s%s', 'helphub' ), $this->singular, strtolower( $this->singular ), '<a target="_blank" href="' . esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) . '">', '</a>' ),
+			9 => sprintf( __( '%s scheduled for: %1$s. %2$sPreview %s%3$s', 'helphub' ), $this->singular, strtolower( $this->singular ),
+			// translators: Publish box date format, see http://php.net/date
+			'<strong>' . date_i18n( __( 'M j, Y @ G:i' ), strtotime( $post->post_date ) ) . '</strong>', '<a target="_blank" href="' . esc_url( get_permalink($post_ID) ) . '">', '</a>' ),
+			10 => sprintf( __( '%s draft updated. %sPreview %s%s', 'helphub' ), $this->singular, strtolower( $this->singular ), '<a target="_blank" href="' . esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) . '">', '</a>' ),
+		);
+
+		return $messages;
+	} // End updated_messages()
+
+	/**
+	 * Setup the meta box.
+	 * You can use separate conditions here to add different meta boxes for different post types
+	 * @access public
+	 * @since  1.0.0
+	 * @return void
+	 */
+	public function meta_box_setup () {
+		if ( $this->post_type == 'post' ) :
+			add_meta_box( $this->post_type . '-display', __( 'Display Settings', 'helphub' ), array( $this, 'meta_box_content' ), $this->post_type, 'normal', 'high' );
+
+		endif;
+	} // End meta_box_setup()
+
+	/**
+	 * The contents of our meta box.
+	 * Duplicate this function for more callbacks
+	 * @access public
+	 * @since  1.0.0
+	 * @return void
+	 */
+
+	public function meta_box_content () {
+		$field_data = $this->get_custom_fields_post_display_settings();
+		$this->meta_box_content_render( $field_data );
+	}
+
+	/**
+	 * The rendering of fields in meta boxes
+	 * @access public
+	 * @since  1.0.0
+	 * @return void
+	 */
+
+	public function meta_box_content_render ( $field_data ) {
+		global $post_id;
+		$fields = get_post_custom( $post_id );
+
+		$html = '';
+
+		$html .= '<input type="hidden" name="helphub_' . $this->post_type . '_noonce" id="helphub_' . $this->post_type . '_noonce" value="' . wp_create_nonce( plugin_basename( dirname( HelpHub_Post_Types()->plugin_path ) ) ) . '" />';
+
+		if ( 0 < count( $field_data ) ) {
+			$html .= '<table class="form-table">' . "\n";
+			$html .= '<tbody>' . "\n";
+
+			foreach ( $field_data as $k => $v ) {
+				$data = $v['default'];
+				if ( isset( $fields['_' . $k] ) && isset( $fields['_' . $k][0] ) ) {
+					$data = $fields['_' . $k][0];
+				}
+
+				switch ( $v['type'] ) {
+					case 'hidden':
+						$field = '<input name="' . esc_attr( $k ) . '" type="hidden" id="' . esc_attr( $k ) . '" value="' . esc_attr( $data ) . '" />';
+						$html .= '<tr valign="top">' . $field . "\n";
+						$html .= '</tr>' . "\n";
+						break;
+					case 'text':
+					case 'url':
+						$field = '<input name="' . esc_attr( $k ) . '" type="text" id="' . esc_attr( $k ) . '" class="regular-text" value="' . esc_attr( $data ) . '" />';
+						$html .= '<tr valign="top"><th scope="row"><label for="' . esc_attr( $k ) . '">' . $v['name'] . '</label></th><td>' . $field . "\n";
+						if( isset( $v['description'] ) ) $html .= '<p class="description">' . $v['description'] . '</p>' . "\n";
+						$html .= '</td></tr>' . "\n";
+						break;
+					case 'textarea':
+						$field = '<textarea name="' . esc_attr( $k ) . '" id="' . esc_attr( $k ) . '" class="large-text">' . esc_attr( $data ) . '</textarea>';
+						$html .= '<tr valign="top"><th scope="row"><label for="' . esc_attr( $k ) . '">' . $v['name'] . '</label></th><td>' . $field . "\n";
+						if( isset( $v['description'] ) ) $html .= '<p class="description">' . $v['description'] . '</p>' . "\n";
+						$html .= '</td></tr>' . "\n";
+						break;
+					case 'editor':
+						ob_start();
+						wp_editor( $data, $k, array( 'media_buttons' => false, 'textarea_rows' => 10 ) );
+						$field = ob_get_contents();
+						ob_end_clean();
+						$html .= '<tr valign="top"><th scope="row"><label for="' . esc_attr( $k ) . '">' . $v['name'] . '</label></th><td>' . $field . "\n";
+						if( isset( $v['description'] ) ) $html .= '<p class="description">' . $v['description'] . '</p>' . "\n";
+						$html .= '</td></tr>' . "\n";
+						break;
+					case 'upload':
+						$data_atts = '';
+						if ( isset( $v['media-frame']['title'] ) ){
+							$data_atts .= sprintf( 'data-title="%s" ', esc_attr( $v['media-frame']['title'] ) );
+						}
+						if ( isset( $v['media-frame']['button'] ) ){
+							$data_atts .= sprintf( 'data-button="%s" ', esc_attr( $v['media-frame']['button'] ) );
+						}
+						if ( isset( $v['media-frame']['library'] ) ){
+							$data_atts .= sprintf( 'data-library="%s" ', esc_attr( $v['media-frame']['library'] ) );
+						}
+
+						$field = '<input name="' . esc_attr( $k ) . '" type="text" id="' . esc_attr( $k ) . '" class="regular-text helphub-upload-field" value="' . esc_attr( $data ) . '" />';
+						$field .= '<button id="' . esc_attr( $k ) . '" class="helphub-upload button"' . $data_atts . '>' . $v['label'] . '</button>';
+						$html .= '<tr valign="top"><th scope="row"><label for="' . esc_attr( $k ) . '">' . $v['name'] . '</label></th><td>' . $field . "\n";
+						if( isset( $v['description'] ) ) $html .= '<p class="description">' . $v['description'] . '</p>' . "\n";
+						$html .= '</td></tr>' . "\n";
+						break;
+					case 'radio':
+						$field = '';
+						if ( isset( $v['options'] ) && is_array( $v['options'] ) ) {
+							foreach ( $v['options'] as $val => $option ){
+								$field .= '<p><label for="' . esc_attr( $v['name'] . '-' . $val ) . '"><input id="' . esc_attr( $v['name'] . '-' . $val ) . '" type="radio" name="' . esc_attr( $k ) . '" value="' . esc_attr( $val ) . '" ' . checked( $val, $data, false ) . ' / >'. $option . '</label></p>' . "\n";
+							}
+						}
+						$html .= '<tr valign="top"><th scope="row"><label>' . $v['name'] . '</label></th><td>' . $field . "\n";
+						if( isset( $v['description'] ) ) $html .= '<p class="description">' . $v['description'] . '</p>' . "\n";
+						$html .= '</td></tr>' . "\n";
+						break;
+					case 'checkbox':
+						$field = '<p><input id="' . esc_attr( $v['name'] ) . '" type="checkbox" name="' . esc_attr( $k ) . '" value="1" ' . checked( 'yes', $data, false ) . ' / ></p>' . "\n";
+						if( isset( $v['description'] ) ) $field .= '<p class="description">' . $v['description'] . '</p>' . "\n";
+						$html .= '<tr valign="top"><th scope="row"><label for="' . esc_attr( $v['name'] ) . '">' . $v['name'] . '</label></th><td>' . $field . "\n";
+						$html .= '</td></tr>' . "\n";
+						break;
+					case 'multicheck':
+						$field = '';
+						if( isset( $v['options'] ) && is_array( $v['options'] ) ){
+							foreach ( $v['options'] as $val => $option ){
+								$field .= '<p><label for="' . esc_attr( $v['name'] . '-' . $val ) . '"><input id="' . esc_attr( $v['name'] . '-' . $val ) . '" type="checkbox" name="' . esc_attr( $k ) . '[]" value="' . esc_attr( $val ) . '" ' . checked( 1, in_array( $val, (array) $data ), false ) . ' / >'. $option . '</label></p>' . "\n";
+							}
+						}
+						$html .= '<tr valign="top"><th scope="row"><label>' . $v['name'] . '</label></th><td>' . $field . "\n";
+						if( isset( $v['description'] ) ) $html .= '<p class="description">' . $v['description'] . '</p>' . "\n";
+						$html .= '</td></tr>' . "\n";
+						break;
+					case 'select':
+						$field = '<select name="' . esc_attr( $k ) . '" id="' . esc_attr( $k ) . '" >'. "\n";
+						if ( isset( $v['options'] ) && is_array( $v['options'] ) ) {
+							foreach ( $v['options'] as $val => $option ){
+								$field .= '<option value="' . esc_attr( $val ) . '" ' . selected( $val, $data, false ) . '>'. $option .'</option>' . "\n";
+							}
+						}
+						$field .= '</select>'. "\n";
+						$html .= '<tr valign="top"><th scope="row"><label for="' . esc_attr( $k ) . '">' . $v['name'] . '</label></th><td>' . $field . "\n";
+						if( isset( $v['description'] ) ) $html .= '<p class="description">' . $v['description'] . '</p>' . "\n";
+						$html .= '</td></tr>' . "\n";
+						break;
+					default:
+						$field = apply_filters( 'helphub_data_field_type_' . $v['type'], null, $k, $data, $v );
+						if ( $field ) {
+							$html .= '<tr valign="top"><th scope="row"><label for="' . esc_attr( $k ) . '">' . $v['name'] . '</label></th><td>' . $field . "\n";
+							if( isset( $v['description'] ) ) $html .= '<p class="description">' . $v['description'] . '</p>' . "\n";
+							$html .= '</td></tr>' . "\n";
+						}
+						break;
+				}
+			}
+
+			$html .= '</tbody>' . "\n";
+			$html .= '</table>' . "\n";
+		}
+
+		echo $html;
+	} // End meta_box_content()
+
+	/**
+	 * Save meta box fields.
+	 * @access public
+	 * @since  1.0.0
+	 * @param int $post_id
+	 * @return int $post_id
+	 */
+	public function meta_box_save ( $post_id ) {
+		global $post, $messages;
+
+		// Verify
+		if ( ( get_post_type() != $this->post_type ) || ! wp_verify_nonce( $_POST['helphub_' . $this->post_type . '_noonce'], plugin_basename( dirname( HelpHub_Post_Types()->plugin_path ) ) ) ) {
+			return $post_id;
+		}
+
+		if ( isset( $_POST['post_type'] ) && 'page' == esc_attr( $_POST['post_type'] ) ) {
+			if ( ! current_user_can( 'edit_page', $post_id ) ) {
+				return $post_id;
+			}
+		} else {
+			if ( ! current_user_can( 'edit_post', $post_id ) ) {
+				return $post_id;
+			}
+		}
+
+		$field_data = $this->get_custom_fields_settings();
+		$fields = array_keys( $field_data );
+
+		foreach ( $fields as $f ) :
+
+			switch ( $field_data[$f]['type'] ) {
+				case 'url':
+					${$f} = isset( $_POST[$f] ) ? esc_url( $_POST[$f] ) : '';
+					break;
+				case 'textarea':
+				case 'editor':
+					${$f} = isset( $_POST[$f] ) ? wp_kses_post( trim( $_POST[$f] ) ) : '';
+					break;
+				case 'checkbox':
+					${$f} = isset( $_POST[$f] ) ? 'yes' : 'no';
+					break;
+				case 'multicheck':
+					// ensure checkbox is array and whitelist accepted values against options
+					${$f} = isset( $_POST[$f] ) && is_array( $field_data[$f]['options'] ) ? (array) array_intersect( (array) $_POST[$f], array_flip( $field_data[$f]['options'] ) ) : '';
+					break;
+				case 'radio':
+				case 'select':
+					// whitelist accepted value against options
+					$values = array();
+					if ( is_array( $field_data[$f]['options'] ) )
+						$values = array_keys( $field_data[$f]['options'] );
+					${$f} = isset( $_POST[$f] ) && in_array( $_POST[$f], $values ) ? $_POST[$f] : '';
+					break;
+				default :
+					${$f} = isset( $_POST[$f] ) ? strip_tags( trim( $_POST[$f] ) ) : '';
+					break;
+			}
+
+			// save it
+			update_post_meta( $post_id, '_' . $f, ${$f} );
+
+		endforeach;
+
+		// Save the project gallery image IDs.
+		$attachment_ids = array_filter( explode( ',', sanitize_text_field( $_POST['helphub_image_gallery'] ) ) );
+		update_post_meta( $post_id, '_helphub_image_gallery', implode( ',', $attachment_ids ) );
+	} // End meta_box_save()
+
+	/**
+	 * Customise the "Enter title here" text.
+	 * @access public
+	 * @since  1.0.0
+	 * @param string $title
+	 * @return string $title
+	 */
+	public function enter_title_here ( $title ) {
+		if ( get_post_type() == $this->post_type ) :
+			if ( get_post_type() == 'post' ):
+				$title = __( 'Enter the article title here', 'helphub' );
+			endif;
+		endif;
+		return $title;
+	} // End enter_title_here()
+
+	/**
+	 * Get the settings for the custom fields.
+	 * Use array merge to get a unified fields array
+	 * eg. $fields = array_merge( $this->get_custom_fields_post_display_settings(), $this->get_custom_fields_post_advertisement_settings(), $this->get_custom_fields_post_spacer_settings() );
+	 *
+	 * @access public
+	 * @since  1.0.0
+	 * @return array
+	 */
+	public function get_custom_fields_settings () {
+
+		$fields = array();
+		if ( get_post_type() == 'post' ) :
+			$fields = $this->get_custom_fields_post_display_settings();
+		endif;
+
+		return $fields;
+
+	} // End get_custom_fields_settings()
+
+	/**
+	 * Get the settings for the post display custom fields.
+	 * @access public
+	 * @since  1.0.0
+	 * @return array
+	 */
+	public function get_custom_fields_post_display_settings () {
+		$fields = array();
+
+
+		$fields['read_time'] = array(
+			'name' => __( 'Article Read Time', 'wingz' ),
+			'description' => __( 'Leave this empty, calculation is automatic', 'helphub' ),
+			'type' => 'text',
+			'default' => '',
+			'section' => 'info'
+		);
+
+		return $fields;
+	}
+
+
+	/**
+	 * Get the image for the given ID.
+	 * @param  int 				$id   Post ID.
+	 * @param  mixed $size Image dimension. (default: "thing-thumbnail")
+	 * @since  1.0.0
+	 * @return string       	<img> tag.
+	 */
+	protected function get_image ( $id, $size = 'thing-thumbnail' ) {
+		$response = '';
+
+		if ( has_post_thumbnail( $id ) ) {
+			// If not a string or an array, and not an integer, default to 150x9999.
+			if ( ( is_int( $size ) || ( 0 < intval( $size ) ) ) && ! is_array( $size ) ) {
+				$size = array( intval( $size ), intval( $size ) );
+			} elseif ( ! is_string( $size ) && ! is_array( $size ) ) {
+				$size = array( 150, 9999 );
+			}
+			$response = get_the_post_thumbnail( intval( $id ), $size );
+		}
+
+		return $response;
+	} // End get_image()
+
+	/**
+	 * Register image sizes.
+	 * @access public
+	 * @since  1.0.0
+	 */
+	public function register_image_sizes () {
+		if ( function_exists( 'add_image_size' ) ) {
+			//add_image_size( $this->post_type . '-thumbnail', 150, 9999 ); // 150 pixels wide (and unlimited height)
+
+		}
+	} // End register_image_sizes()
+
+	/**
+	 * Run on activation.
+	 * @access public
+	 * @since 1.0.0
+	 */
+	public function activation () {
+		$this->flush_rewrite_rules();
+	} // End activation()
+
+	/**
+	 * Flush the rewrite rules
+	 * @access public
+	 * @since 1.0.0
+	 */
+	private function flush_rewrite_rules () {
+		$this->register_post_type();
+		flush_rewrite_rules();
+	} // End flush_rewrite_rules()
+
+	/**
+	 * Ensure that "post-thumbnails" support is available for those themes that don't register it.
+	 * @access public
+	 * @since  1.0.0
+	 */
+	public function ensure_post_thumbnails_support () {
+		if ( ! current_theme_supports( 'post-thumbnails' ) ) { add_theme_support( 'post-thumbnails' ); }
+	} // End ensure_post_thumbnails_support()
+
+	/**
+	 * Add menu order
+	 * @access public
+	 * @since  1.0.0
+	 */
+	public function add_menu_order () {
+		add_post_type_support( 'post', 'page-attributes' );
+	} // End ens
+
+} // End Class

--- a/plugins/helphub-post-types/classes/class-helphub-post-types-taxonomy.php
+++ b/plugins/helphub-post-types/classes/class-helphub-post-types-taxonomy.php
@@ -1,0 +1,131 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly.
+
+/**
+ * Helphub Post Types Taxonomy Class
+ *
+ * Re-usable class for registering post type taxonomies.
+ *
+ * @package WordPress
+ * @subpackage HelpHub_Post_Types
+ * @category Plugin
+ * @author Jon Ang
+ * @since 1.0.0
+ */
+class HelpHub_Post_Types_Taxonomy {
+	/**
+	 * The post type to register the taxonomy for.
+	 * @access  private
+	 * @since   1.3.0
+	 * @var     string
+	 */
+	private $post_type;
+
+	/**
+	 * The key of the taxonomy.
+	 * @access  private
+	 * @since   1.3.0
+	 * @var     string
+	 */
+	private $token;
+
+	/**
+	 * The singular name for the taxonomy.
+	 * @access  private
+	 * @since   1.3.0
+	 * @var     string
+	 */
+	private $singular;
+
+	/**
+	 * The plural name for the taxonomy.
+	 * @access  private
+	 * @since   1.3.0
+	 * @var     string
+	 */
+	private $plural;
+
+	/**
+	 * The arguments to use when registering the taxonomy.
+	 * @access  private
+	 * @since   1.3.0
+	 * @var     string
+	 */
+	private $args;
+
+	/**
+	 * Class constructor.
+	 * @access  public
+	 * @since   1.3.0
+	 * @param   string $post_type The post type key.
+	 * @param   string $token     The taxonomy key.
+	 * @param   string $singular  Singular name.
+	 * @param   string $plural    Plural  name.
+	 * @param   array  $args      Array of argument overrides.
+	 */
+	public function __construct ( $post_type = 'thing', $token = 'thing-category', $singular = '', $plural = '', $args = array() ) {
+		$this->post_type = $post_type;
+		$this->token = esc_attr( $token );
+		$this->singular = esc_html( $singular );
+		$this->plural = esc_html( $plural );
+
+		if ( '' == $this->singular ) $this->singular = __( 'Category', 'helphub' );
+		if ( '' == $this->plural ) $this->plural = __( 'Categories', 'helphub' );
+
+		$this->args = wp_parse_args( $args, $this->_get_default_args() );
+		
+		add_action( 'init', array( $this, 'register' ) );
+	} // End __construct()
+
+	/**
+	 * Return an array of default arguments.
+	 * @access  private
+	 * @since   1.3.0
+	 * @return  array Default arguments.
+	 */
+	private function _get_default_args () {
+		return array(
+			'labels'                => $this->_get_default_labels(),
+			'public'                => true,
+			'hierarchical'          => true,
+			'show_ui'               => true,
+			'show_admin_column'     => true,
+			'query_var'             => true,
+			'show_in_nav_menus'     => false,
+			'show_tagcloud'         => false,
+			'rewrite'               => array( 'slug' => str_replace( 'helphub_', '', esc_attr( $this->token ) ) )
+		);
+	} // End _get_default_args()
+
+	/**
+	 * Return an array of default labels.
+	 * @access  private
+	 * @since   1.3.0
+	 * @return  array Default labels.
+	 */
+	private function _get_default_labels () {
+		return array(
+			    'name'                => sprintf( _x( '%s', 'taxonomy general name', 'helphub' ), $this->plural ),
+			    'singular_name'       => sprintf( _x( '%s', 'taxonomy singular name', 'helphub' ), $this->singular ),
+			    'search_items'        => sprintf( __( 'Search %s', 'helphub' ), $this->plural ),
+			    'all_items'           => sprintf( __( 'All %s', 'helphub' ), $this->plural ),
+			    'parent_item'         => sprintf( __( 'Parent %s', 'helphub' ), $this->singular ),
+			    'parent_item_colon'   => sprintf( __( 'Parent %s:', 'helphub' ), $this->singular ),
+			    'edit_item'           => sprintf( __( 'Edit %s', 'helphub' ), $this->singular ),
+			    'update_item'         => sprintf( __( 'Update %s', 'helphub' ), $this->singular ),
+			    'add_new_item'        => sprintf( __( 'Add New %s', 'helphub' ), $this->singular ),
+			    'new_item_name'       => sprintf( __( 'New %s Name', 'helphub' ), $this->singular ),
+			    'menu_name'           => sprintf( __( '%s', 'helphub' ), $this->plural )
+			  );
+	} // End _get_default_labels()
+
+	/**
+	 * Register the taxonomy.
+	 * @access  public
+	 * @since   1.3.0
+	 * @return  void
+	 */
+	public function register () {
+		register_taxonomy( esc_attr( $this->token ), esc_attr( $this->post_type ), (array)$this->args );
+	} // End register()
+} // End Class

--- a/plugins/helphub-post-types/classes/index.php
+++ b/plugins/helphub-post-types/classes/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden... ?>

--- a/plugins/helphub-post-types/helphub-post-types.php
+++ b/plugins/helphub-post-types/helphub-post-types.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Plugin Name: Helphub Post Types
+ * Plugin URI: http://www.wordpress.org
+ * Description: This is what powers Post Types and Taxonomies.
+ * Version: 1.0.0
+ * Author: Jon Ang
+ * Author URI: http://www.helphubcommunications.com/
+ * Requires at least: 4.0.0
+ * Tested up to: 4.0.0
+ *
+ * Text Domain: helphub
+ * Domain Path: /languages/
+ *
+ * @package HelpHub_Post_Types
+ * @category Core
+ * @author Jon Ang
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
+/**
+ * Returns the main instance of HelpHub_Post_Types to prevent the need to use globals.
+ *
+ * @since  1.0.0
+ * @return object HelpHub_Post_Types
+ */
+function HelpHub_Post_Types() {
+	return HelpHub_Post_Types::instance();
+} // End HelpHub_Post_Types()
+
+add_action( 'plugins_loaded', 'HelpHub_Post_Types' );
+
+/**
+ * Main HelpHub_Post_Types Class
+ *
+ * @class HelpHub_Post_Types
+ * @version	1.0.0
+ * @since 1.0.0
+ * @package	HelpHub_Post_Types
+ * @author Jon Ang
+ */
+final class HelpHub_Post_Types {
+	/**
+	 * HelpHub_Post_Types The single instance of HelpHub_Post_Types.
+	 * @var 	object
+	 * @access  private
+	 * @since 	1.0.0
+	 */
+	private static $_instance = null;
+
+	/**
+	 * The token.
+	 * @var     string
+	 * @access  public
+	 * @since   1.0.0
+	 */
+	public $token;
+
+	/**
+	 * The version number.
+	 * @var     string
+	 * @access  public
+	 * @since   1.0.0
+	 */
+	public $version;
+
+	/**
+	 * The plugin directory URL.
+	 * @var     string
+	 * @access  public
+	 * @since   1.0.0
+	 */
+	public $plugin_url;
+
+	/**
+	 * The plugin directory path.
+	 * @var     string
+	 * @access  public
+	 * @since   1.0.0
+	 */
+	public $plugin_path;
+
+	// Admin - Start
+	/**
+	 * The admin object.
+	 * @var     object
+	 * @access  public
+	 * @since   1.0.0
+	 */
+	public $admin;
+
+	/**
+	 * The settings object.
+	 * @var     object
+	 * @access  public
+	 * @since   1.0.0
+	 */
+	public $settings;
+	// Admin - End
+
+	// Post Types - Start
+	/**
+	 * The post types we're registering.
+	 * @var     array
+	 * @access  public
+	 * @since   1.0.0
+	 */
+	public $post_types = array();
+	// Post Types - End
+	
+	// Taxonomies - Start
+	/**
+	 * The taxonomies we're registering.
+	 * @var     array
+	 * @access  public
+	 * @since   1.0.0
+	 */
+	public $taxonomies = array();
+	// Taxonomies - End
+	
+	/**
+	 * Constructor function.
+	 * @access  public
+	 * @since   1.0.0
+	 */
+	public function __construct () {
+		$this->token 			= 'helphub';
+		$this->plugin_url 		= plugin_dir_url( __FILE__ );
+		$this->plugin_path 		= plugin_dir_path( __FILE__ );
+		$this->version 			= '1.0.0';
+
+
+		// Post Types - Start
+		require_once( 'classes/class-helphub-post-types-post-type.php' );
+		require_once( 'classes/class-helphub-post-types-taxonomy.php' );
+
+		// Register an example post type. To register other post types, duplicate this line.
+		$this->post_types['post'] = new HelpHub_Post_Types_Post_Type( 'post', __( 'Post', 'helphub' ), __( 'Posts', 'helphub' ), array( 'menu_icon' => 'dashicons-post' ) );
+
+		// Post Types - End
+		
+		//Register an example taxonomy. To register more taxonomies, duplicate this line.
+		$this->taxonomies['helphub_persona']  = new HelpHub_Post_Types_Taxonomy( 'post', 'helphub_persona', __( 'Persona', 'helphub' ), __( 'Personas', 'helphub' ) );
+		$this->taxonomies['helphub_experience']   = new HelpHub_Post_Types_Taxonomy( 'post', 'helphub_experience', __( 'Experience', 'helphub' ), __( 'Experiences', 'helphub' ) );
+
+		register_activation_hook( __FILE__, array( $this, 'install' ) );
+
+		add_action( 'init', array( $this, 'load_plugin_textdomain' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_styles' ) );
+	} // End __construct()
+
+	/**
+	 * Main HelpHub_Post_Types Instance
+	 *
+	 * Ensures only one instance of HelpHub_Post_Types is loaded or can be loaded.
+	 *
+	 * @since 1.0.0
+	 * @static
+	 * @see HelpHub_Post_Types()
+	 * @return Main HelpHub_Post_Types instance
+	 */
+	public static function instance () {
+		if ( is_null( self::$_instance ) )
+			self::$_instance = new self();
+		return self::$_instance;
+	} // End instance()
+
+	/**
+	 * Load the localisation file.
+	 * @access  public
+	 * @since   1.0.0
+	 */
+	public function load_plugin_textdomain() {
+		load_plugin_textdomain( 'helphub', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+	} // End load_plugin_textdomain()
+
+	/**
+	 * Enqueue post type admin Styles.
+	 *
+	 * @access public
+	 * @since   1.0.0
+	 * @return   void
+	 */
+	public function enqueue_admin_styles () {
+		global $pagenow;
+
+		wp_enqueue_style( 'helphub-post-types-admin-style', $this->plugin_url . 'assets/css/admin.css', array(), '1.0.0' );
+
+		if ( ( $pagenow == 'post.php' || $pagenow == 'post-new.php' ) ):
+			if ( array_key_exists( get_post_type(), $this->post_types ) ):
+				wp_enqueue_script( 'helphub-post-types-admin', $this->plugin_url . 'assets/js/admin.js', array( 'jquery' ), '1.0.0', true );
+				wp_enqueue_script( 'helphub-post-types-gallery', $this->plugin_url . 'assets/js/gallery.js', array( 'jquery' ), '1.0.0', true );
+			endif;
+		endif;
+		wp_localize_script( 'helphub-post-types-admin', 'helphub_admin',
+			array(
+				'default_title' 	=> __( 'Upload', 'wingz' ),
+				'default_button' 	=> __( 'Select this', 'wingz' ),
+			)
+		);
+
+		wp_localize_script( 'helphub-post-types-gallery', 'helphub_gallery',
+			array(
+				'gallery_title' 	=> __( 'Add Images to Product Gallery', 'wingz' ),
+				'gallery_button' 	=> __( 'Add to gallery', 'wingz' ),
+				'delete_image'		=> __( 'Delete image', 'wingz' ),
+			)
+		);
+
+
+	} // End enqueue_admin_styles()
+
+	/**
+	 * Cloning is forbidden.
+	 * @access public
+	 * @since 1.0.0
+	 */
+	public function __clone () {
+		_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?' ), '1.0.0' );
+	} // End __clone()
+
+	/**
+	 * Unserializing instances of this class is forbidden.
+	 * @access public
+	 * @since 1.0.0
+	 */
+	public function __wakeup () {
+		_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?' ), '1.0.0' );
+	} // End __wakeup()
+
+	/**
+	 * Installation. Runs on activation.
+	 * @access  public
+	 * @since   1.0.0
+	 */
+	public function install () {
+		$this->_log_version_number();
+	} // End install()
+
+	/**
+	 * Log the plugin version number.
+	 * @access  private
+	 * @since   1.0.0
+	 */
+	private function _log_version_number () {
+		// Log the version number.
+		update_option( $this->token . '-version', $this->version );
+	} // End _log_version_number()
+} // End Class

--- a/plugins/helphub-post-types/index.php
+++ b/plugins/helphub-post-types/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden... ?>

--- a/plugins/helphub-post-types/readme.txt
+++ b/plugins/helphub-post-types/readme.txt
@@ -1,0 +1,46 @@
+=== Helphub Post Types ===
+Contributors: Jon Ang
+Donate link:
+Tags: 1.1
+Requires at least: 4.0.0
+Tested up to: 4.0.0
+Stable tag: 1.1.0
+License: GPLv3 or later
+License URI: http://www.gnu.org/licenses/gpl-3.0.html
+
+Hey there! This powers the Frontpage Magazine
+
+== Description ==
+
+Hey there! I create Post Types, custom meta fields, taxonomies and sanitise them.
+
+Looking for a helping hand? Contact Jon
+
+== Usage ==
+
+
+
+== Installation ==
+
+Installing "Helphub Post Types" can be done either by searching for "Helphub Post Types" via the "Plugins > Add New" screen in your WordPress dashboard, or by using the following steps:
+
+1. Upload the ZIP file through the "Plugins > Add New > Upload" screen in your WordPress dashboard.
+2. Activate the plugin through the 'Plugins' menu in WordPress
+3. Visit the settings screen and configure, as desired.
+
+== Frequently Asked Questions ==
+
+
+
+== Upgrade Notice ==
+
+= 1.0.0 =
+* XXXX-XX-XX
+* Initial release. Woo!
+
+== Changelog ==
+
+= 1.1.0 =
+
+= 1.0.0 =
+* Initial release. Woo!


### PR DESCRIPTION
This allows us to easily add new custom post types, taxonomies and meta fields without defining new sanitisation, or saving code.

Meta fields supported
- Hidden
- Text
- URL
- Text Area
- WP Editor
- Upload
- Radio
- Checkbox
- Multicheck
- Select
- Gallery
