### PR TITLE
make phpcs ruleset the same with twentyseventeen

### DIFF
--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -1,15 +1,28 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress Coding Standards via https://github.com/Automattic/_s/blob/master/codesniffer.ruleset.xml">
+<ruleset name="WordPress Theme Coding Standards">
 	<!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
 	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress-Core/ruleset.xml -->
 
 	<!-- Set a description for this ruleset. -->
 	<description>A custom set of code standard rules to check for WordPress themes.</description>
 
-	<!-- Include the WordPress ruleset, with exclusions. -->
-	<rule ref="WordPress">
-		<exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
+	<!-- Include the WordPress ruleset, with space for exclusions if necessary. -->
+	<rule ref="WordPress-Core">
 		<exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
+		<exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
+
 		<exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
+
+		<exclude name="Squiz.Commenting.FileComment.SpacingAfterComment" />
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag" />
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
+		<exclude name="Squiz.Commenting.InlineComment.NotCapital" />
+	</rule>
+	<rule ref="WordPress-Docs">
+
+	</rule>
+
+	<rule ref="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing">
+		<severity>0</severity>
 	</rule>
 </ruleset>

--- a/themes/helphub/template-parts/widget-homewidgets.php
+++ b/themes/helphub/template-parts/widget-homewidgets.php
@@ -6,7 +6,9 @@
  *
  * @package HelpHub
  */
+
 ?>
+
 <div class="helphub-homewidget-row1">
-  <?php dynamic_sidebar( 'homewidgetrow-1' ); ?>
+	<?php dynamic_sidebar( 'homewidgetrow-1' ); ?>
 </div>


### PR DESCRIPTION
I am trying to fix problems on Travis CI.
But ruleset of the phpcs looks too strict. 😈 

For example:
```
<?php
/**
 * The widget footer 2
 *
 * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
 *
 * @package HelpHub
 */
?>

<div class="helphub-homewidget-row1">
	<?php dynamic_sidebar( 'homewidgetrow-1' ); ?>
</div>
```

`themes/widget-homewidget.php` have following errors.

```
FILE: ...top/HelpHub/themes/helphub/template-parts/widget-homewidgets.php
----------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
----------------------------------------------------------------------
  8 | ERROR | [ ] There must be exactly one blank line after the file
    |       |     comment
    |       |     (Squiz.Commenting.FileComment.SpacingAfterComment)
 11 | ERROR | [x] Tabs must be used to indent lines; spaces are not
    |       |     allowed
    |       |     (Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed)
----------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------
```

The error about tab is OK, but It seems very difficult to fix errors on comments.

This PR makes phpcs ruleset the same with twentyseventeen project.
https://github.com/WordPress/twentyseventeen/blob/master/codesniffer.ruleset.xml