### PR TITLE
fix phpcs errors on theme

### DIFF
--- a/themes/helphub/comments.php
+++ b/themes/helphub/comments.php
@@ -27,11 +27,27 @@ if ( post_password_required() ) {
 	if ( have_comments() ) : ?>
 		<h2 class="comments-title">
 			<?php
-				printf( // WPCS: XSS OK.
-					esc_html( _nx( 'One thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', get_comments_number(), 'comments title', 'helphub' ) ),
-					number_format_i18n( get_comments_number() ),
-					'<span>' . get_the_title() . '</span>'
-				);
+				$comments_number = get_comments_number();
+				if ( 1 === $comments_number ) {
+					printf(
+						/* translators: %s: post title */
+						esc_html_x( 'One thought on &ldquo;%s&rdquo;', 'comments title', 'helphub' ),
+						'<span>' . get_the_title() . '</span>'
+					);
+				} else {
+					printf( // WPCS: XSS OK.
+						/* translators: 1: number of comments, 2: post title */
+						esc_html( _nx(
+							'%1$s thought on &ldquo;%2$s&rdquo;',
+							'%1$s thoughts on &ldquo;%2$s&rdquo;',
+							$comments_number,
+							'comments title',
+							'helphub'
+						) ),
+						number_format_i18n( $comments_number ),
+						'<span>' . get_the_title() . '</span>'
+					);
+				}
 			?>
 		</h2>
 

--- a/themes/helphub/footer.php
+++ b/themes/helphub/footer.php
@@ -15,17 +15,17 @@
 	</div><!-- #content wrapper -->
 	<div class="helphub-footerarea">
 		<div class="wrapper">
-			<h2 class="helphub-footerarea-title"><?php echo __( 'Join the Conversation and Learn More', 'helphub' ); ?></h2>
+			<h2 class="helphub-footerarea-title"><?php echo esc_html__( 'Join the Conversation and Learn More', 'helphub' ); ?></h2>
 			<div class="helphub-footerarea1">
 				<?php
 					if ( is_active_sidebar( 'footer-1' ) ) {
 						get_template_part( 'template-parts/widget', 'footer1' );
 					} else { ?>
 						<h2 class="widget-title">
-							<?php echo __( 'Footer 1 Title', 'helphub' ); ?>
+							<?php echo esc_html__( 'Footer 1 Title', 'helphub' ); ?>
 						</h2>
 						<div class="textwidget">
-							<?php echo __( 'This is the Footer 1 sidebar. Please assign a widget to here', 'helphub' ); ?>
+							<?php echo esc_html__( 'This is the Footer 1 sidebar. Please assign a widget to here', 'helphub' ); ?>
 						</div> <?php
 					}
 				?>
@@ -36,10 +36,10 @@
 						get_template_part( 'template-parts/widget', 'footer1' );
 					} else { ?>
 						<h2 class="widget-title">
-							<?php echo __( 'Footer 2 Title', 'helphub' ); ?>
+							<?php echo esc_html__( 'Footer 2 Title', 'helphub' ); ?>
 						</h2>
 						<div class="textwidget">
-							<?php echo __( 'This is the Footer 2 sidebar. Please assign a widget to here', 'helphub' ); ?>
+							<?php echo esc_html__( 'This is the Footer 2 sidebar. Please assign a widget to here', 'helphub' ); ?>
 						</div> <?php
 					}
 				?>

--- a/themes/helphub/functions.php
+++ b/themes/helphub/functions.php
@@ -137,7 +137,7 @@ function helphub_widgets_init() {
 	register_sidebar( array(
 		'name'          => esc_html__( 'Footer 2', 'helphub' ),
 		'id'            => 'footer-2',
-		'description'   => esc_html__('This widget area appears on the right side before the footer.', 'helphub'),
+		'description'   => esc_html__( 'This widget area appears on the right side before the footer.', 'helphub' ),
 		'before_widget' => '<section id="%1$s" class="widget %2$s">',
 		'after_widget'  => '</section>',
 		'before_title'  => '<h2 class="widget-title">',

--- a/themes/helphub/template-frontpage.php
+++ b/themes/helphub/template-frontpage.php
@@ -5,9 +5,9 @@
  * If the user has selected a static page for their homepage, this is what will
  * appear. Learn more: http://codex.wordpress.org/Template_Hierarchy
  *
- *
  * @package components
  */
+
 /**
  * Load pattern maker file.
  */
@@ -25,7 +25,7 @@ get_header(); ?>
 					?>
 				</div>
 				<div class="helphub-contentarea">
-					<?php	while ( have_posts() ) : the_post(); // start the loop?>
+					<?php while ( have_posts() ) : the_post(); // start the loop. ?>
 						<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 							<div class="entry-content">
 								<?php

--- a/themes/helphub/template-parts/content-post.php
+++ b/themes/helphub/template-parts/content-post.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Template part for displaying page content in page.php.
+ *
  * @Author Jon Ang
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
@@ -9,42 +10,42 @@
 
 ?>
 <aside class="single-post-sidebar">
-    Test
+	Test
 </aside>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 
 
-    <div class="entry-content">
-        <header class="entry-header">
-            <?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
-            
-            <span class="read-time">
-                <?php helphub_wrap_the_read_time(); ?>
-            </span>
-        </header><!-- .entry-header -->
-        <?php
-        the_content();
+	<div class="entry-content">
+		<header class="entry-header">
+			<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
 
-        wp_link_pages( array(
-            'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'helphub' ),
-            'after'  => '</div>',
-        ) );
-        ?>
-        <footer class="entry-footer">
-            <?php
-            edit_post_link(
-                sprintf(
-                /* translators: %s: Name of current post */
-                    esc_html__( 'Edit %s', 'helphub' ),
-                    the_title( '<span class="screen-reader-text">"', '"</span>', false )
-                ),
-                '<span class="edit-link">',
-                '</span>'
-            );
-            ?>
-        </footer><!-- .entry-footer -->
-    </div><!-- .entry-content -->
+			<span class="read-time">
+				<?php helphub_wrap_the_read_time(); ?>
+			</span>
+		</header><!-- .entry-header -->
+		<?php
+		the_content();
+
+		wp_link_pages( array(
+			'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'helphub' ),
+			'after'  => '</div>',
+		) );
+		?>
+		<footer class="entry-footer">
+			<?php
+			edit_post_link(
+				sprintf(
+				/* translators: %s: Name of current post */
+					esc_html__( 'Edit %s', 'helphub' ),
+					the_title( '<span class="screen-reader-text">"', '"</span>', false )
+				),
+				'<span class="edit-link">',
+				'</span>'
+			);
+			?>
+		</footer><!-- .entry-footer -->
+	</div><!-- .entry-content -->
 
 
 

--- a/themes/helphub/template-parts/widget-footer1.php
+++ b/themes/helphub/template-parts/widget-footer1.php
@@ -6,6 +6,9 @@
  *
  * @package HelpHub
  */
+
 ?>
 
-<?php dynamic_sidebar( 'footer-1' ); ?>
+<?php
+
+dynamic_sidebar( 'footer-1' );

--- a/themes/helphub/template-parts/widget-footer2.php
+++ b/themes/helphub/template-parts/widget-footer2.php
@@ -6,6 +6,9 @@
  *
  * @package HelpHub
  */
+
 ?>
 
-<?php dynamic_sidebar( 'footer-2' ); ?>
+<?php
+
+dynamic_sidebar( 'footer-2' );

--- a/themes/helphub/template-parts/widget-homesearch.php
+++ b/themes/helphub/template-parts/widget-homesearch.php
@@ -6,6 +6,9 @@
  *
  * @package HelpHub
  */
+
 ?>
 
-<?php dynamic_sidebar( 'homewidgetsearch-1' ); ?>
+<?php
+
+dynamic_sidebar( 'homewidgetsearch-1' );

--- a/themes/helphub/template-parts/widget-homewidgets.php
+++ b/themes/helphub/template-parts/widget-homewidgets.php
@@ -6,7 +6,9 @@
  *
  * @package HelpHub
  */
+
 ?>
+
 <div class="helphub-homewidget-row1">
-  <?php dynamic_sidebar( 'homewidgetrow-1' ); ?>
+	<?php dynamic_sidebar( 'homewidgetrow-1' ); ?>
 </div>


### PR DESCRIPTION
Fix problems with phpcs in the theme.

Note:
I got following error in `themes/helphub/comments.php` and fix it in the same way as `_s`.

```
FILE: /Users/miyauchi/Desktop/HelpHub/themes/helphub/comments.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 31 | ERROR | Missing singular placeholder, needed for some languages.
    |       | See
    |       | https://codex.wordpress.org/I18n_for_WordPress_Developers#Plurals
    |       | (WordPress.WP.I18n.MissingSingularPlaceholder)
----------------------------------------------------------------------
```

https://github.com/Automattic/_s/commit/a626d603c1ce4e5d82f625575fcb288e129874c5