### PR TITLE
exclude the syntaxhighlighter plugin

### DIFF
--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -6,6 +6,8 @@
 	<!-- Set a description for this ruleset. -->
 	<description>A custom set of code standard rules to check for WordPress themes.</description>
 
+	<exclude-pattern>plugins/syntaxhighlighter/*</exclude-pattern>
+
 	<!-- Include the WordPress ruleset, with exclusions. -->
 	<rule ref="WordPress">
 		<exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />


### PR DESCRIPTION
Excludes the syntaxhighlighter plugin from phpcs tests, because it is third-party plugin.