### PR TITLE
fix phpcs errors in helphub-post-types plugin

### DIFF
--- a/plugins/helphub-post-types/classes/class-helphub-post-types-taxonomy.php
+++ b/plugins/helphub-post-types/classes/class-helphub-post-types-taxonomy.php
@@ -73,7 +73,7 @@ class HelpHub_Post_Types_Taxonomy {
 		if ( '' == $this->plural ) $this->plural = __( 'Categories', 'helphub' );
 
 		$this->args = wp_parse_args( $args, $this->_get_default_args() );
-		
+
 		add_action( 'init', array( $this, 'register' ) );
 	} // End __construct()
 

--- a/plugins/helphub-post-types/classes/index.php
+++ b/plugins/helphub-post-types/classes/index.php
@@ -1,1 +1,5 @@
-<?php // Silence is golden... ?>
+<?php
+/**
+ * Silence is golden.
+ * @codingStandardsIgnoreFile
+ */

--- a/plugins/helphub-post-types/helphub-post-types.php
+++ b/plugins/helphub-post-types/helphub-post-types.php
@@ -17,7 +17,9 @@
  * @author Jon Ang
  */
 
-if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
 
 /**
  * Returns the main instance of HelpHub_Post_Types to prevent the need to use globals.
@@ -25,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
  * @since  1.0.0
  * @return object HelpHub_Post_Types
  */
-function HelpHub_Post_Types() {
+function helphub_post_types() {
 	return HelpHub_Post_Types::instance();
 } // End HelpHub_Post_Types()
 
@@ -43,6 +45,7 @@ add_action( 'plugins_loaded', 'HelpHub_Post_Types' );
 final class HelpHub_Post_Types {
 	/**
 	 * HelpHub_Post_Types The single instance of HelpHub_Post_Types.
+	 *
 	 * @var 	object
 	 * @access  private
 	 * @since 	1.0.0
@@ -51,6 +54,7 @@ final class HelpHub_Post_Types {
 
 	/**
 	 * The token.
+	 *
 	 * @var     string
 	 * @access  public
 	 * @since   1.0.0
@@ -59,6 +63,7 @@ final class HelpHub_Post_Types {
 
 	/**
 	 * The version number.
+	 *
 	 * @var     string
 	 * @access  public
 	 * @since   1.0.0
@@ -67,6 +72,7 @@ final class HelpHub_Post_Types {
 
 	/**
 	 * The plugin directory URL.
+	 *
 	 * @var     string
 	 * @access  public
 	 * @since   1.0.0
@@ -75,15 +81,17 @@ final class HelpHub_Post_Types {
 
 	/**
 	 * The plugin directory path.
+	 *
 	 * @var     string
 	 * @access  public
 	 * @since   1.0.0
 	 */
 	public $plugin_path;
 
-	// Admin - Start
+	/* Admin - Start */
 	/**
 	 * The admin object.
+	 *
 	 * @var     object
 	 * @access  public
 	 * @since   1.0.0
@@ -92,55 +100,58 @@ final class HelpHub_Post_Types {
 
 	/**
 	 * The settings object.
+	 *
 	 * @var     object
 	 * @access  public
 	 * @since   1.0.0
 	 */
 	public $settings;
-	// Admin - End
+	/* Admin - End */
 
-	// Post Types - Start
+	/* Post Types - Start */
 	/**
 	 * The post types we're registering.
+	 *
 	 * @var     array
 	 * @access  public
 	 * @since   1.0.0
 	 */
 	public $post_types = array();
-	// Post Types - End
-	
-	// Taxonomies - Start
+	/* Post Types - End */
+
+	/* Taxonomies - Start */
 	/**
 	 * The taxonomies we're registering.
+	 *
 	 * @var     array
 	 * @access  public
 	 * @since   1.0.0
 	 */
 	public $taxonomies = array();
-	// Taxonomies - End
-	
+	/* Taxonomies - End */
+
 	/**
 	 * Constructor function.
+	 *
 	 * @access  public
 	 * @since   1.0.0
 	 */
-	public function __construct () {
-		$this->token 			= 'helphub';
-		$this->plugin_url 		= plugin_dir_url( __FILE__ );
-		$this->plugin_path 		= plugin_dir_path( __FILE__ );
-		$this->version 			= '1.0.0';
+	public function __construct() {
+		$this->token        = 'helphub';
+		$this->plugin_url   = plugin_dir_url( __FILE__ );
+		$this->plugin_path  = plugin_dir_path( __FILE__ );
+		$this->version      = '1.0.0';
 
-
-		// Post Types - Start
+		/* Post Types - Start */
 		require_once( 'classes/class-helphub-post-types-post-type.php' );
 		require_once( 'classes/class-helphub-post-types-taxonomy.php' );
 
 		// Register an example post type. To register other post types, duplicate this line.
 		$this->post_types['post'] = new HelpHub_Post_Types_Post_Type( 'post', __( 'Post', 'helphub' ), __( 'Posts', 'helphub' ), array( 'menu_icon' => 'dashicons-post' ) );
 
-		// Post Types - End
-		
-		//Register an example taxonomy. To register more taxonomies, duplicate this line.
+		/* Post Types - End */
+
+		// Register an example taxonomy. To register more taxonomies, duplicate this line.
 		$this->taxonomies['helphub_persona']  = new HelpHub_Post_Types_Taxonomy( 'post', 'helphub_persona', __( 'Persona', 'helphub' ), __( 'Personas', 'helphub' ) );
 		$this->taxonomies['helphub_experience']   = new HelpHub_Post_Types_Taxonomy( 'post', 'helphub_experience', __( 'Experience', 'helphub' ), __( 'Experiences', 'helphub' ) );
 
@@ -160,14 +171,16 @@ final class HelpHub_Post_Types {
 	 * @see HelpHub_Post_Types()
 	 * @return Main HelpHub_Post_Types instance
 	 */
-	public static function instance () {
-		if ( is_null( self::$_instance ) )
+	public static function instance() {
+		if ( is_null( self::$_instance ) ) {
 			self::$_instance = new self();
+		}
 		return self::$_instance;
 	} // End instance()
 
 	/**
 	 * Load the localisation file.
+	 *
 	 * @access  public
 	 * @since   1.0.0
 	 */
@@ -182,68 +195,71 @@ final class HelpHub_Post_Types {
 	 * @since   1.0.0
 	 * @return   void
 	 */
-	public function enqueue_admin_styles () {
+	public function enqueue_admin_styles() {
 		global $pagenow;
 
 		wp_enqueue_style( 'helphub-post-types-admin-style', $this->plugin_url . 'assets/css/admin.css', array(), '1.0.0' );
 
-		if ( ( $pagenow == 'post.php' || $pagenow == 'post-new.php' ) ):
-			if ( array_key_exists( get_post_type(), $this->post_types ) ):
+		if ( ( 'post.php' === $pagenow || 'post-new.php' === $pagenow ) ) :
+			if ( array_key_exists( get_post_type(), $this->post_types ) ) :
 				wp_enqueue_script( 'helphub-post-types-admin', $this->plugin_url . 'assets/js/admin.js', array( 'jquery' ), '1.0.0', true );
 				wp_enqueue_script( 'helphub-post-types-gallery', $this->plugin_url . 'assets/js/gallery.js', array( 'jquery' ), '1.0.0', true );
 			endif;
 		endif;
 		wp_localize_script( 'helphub-post-types-admin', 'helphub_admin',
 			array(
-				'default_title' 	=> __( 'Upload', 'wingz' ),
-				'default_button' 	=> __( 'Select this', 'wingz' ),
+				'default_title' 	=> __( 'Upload', 'helphub' ),
+				'default_button' 	=> __( 'Select this', 'helphub' ),
 			)
 		);
 
 		wp_localize_script( 'helphub-post-types-gallery', 'helphub_gallery',
 			array(
-				'gallery_title' 	=> __( 'Add Images to Product Gallery', 'wingz' ),
-				'gallery_button' 	=> __( 'Add to gallery', 'wingz' ),
-				'delete_image'		=> __( 'Delete image', 'wingz' ),
+				'gallery_title' 	=> __( 'Add Images to Product Gallery', 'helphub' ),
+				'gallery_button' 	=> __( 'Add to gallery', 'helphub' ),
+				'delete_image'		=> __( 'Delete image', 'helphub' ),
 			)
 		);
-
 
 	} // End enqueue_admin_styles()
 
 	/**
 	 * Cloning is forbidden.
+	 *
 	 * @access public
 	 * @since 1.0.0
 	 */
-	public function __clone () {
-		_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?' ), '1.0.0' );
+	public function __clone() {
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'helphub' ), '1.0.0' );
 	} // End __clone()
 
 	/**
 	 * Unserializing instances of this class is forbidden.
+	 *
 	 * @access public
 	 * @since 1.0.0
 	 */
-	public function __wakeup () {
-		_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?' ), '1.0.0' );
+	public function __wakeup() {
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'helphub' ), '1.0.0' );
 	} // End __wakeup()
 
 	/**
 	 * Installation. Runs on activation.
+	 *
 	 * @access  public
 	 * @since   1.0.0
 	 */
-	public function install () {
+	public function install() {
 		$this->_log_version_number();
 	} // End install()
 
 	/**
 	 * Log the plugin version number.
+	 *
 	 * @access  private
 	 * @since   1.0.0
 	 */
-	private function _log_version_number () {
+	private function _log_version_number() {
 		// Log the version number.
 		update_option( $this->token . '-version', $this->version );
 	} // End _log_version_number()

--- a/plugins/helphub-post-types/index.php
+++ b/plugins/helphub-post-types/index.php
@@ -1,1 +1,5 @@
-<?php // Silence is golden... ?>
+<?php
+/**
+ * Silence is golden.
+ * @codingStandardsIgnoreFile
+ */


### PR DESCRIPTION
Fix phpcs error in helphub-post-types plugin.

Note:
I haven't fix errors in the `classes/` yet.