### PR TITLE
fix notice on class-helphub-post-types-post-type.php

### DIFF
--- a/plugins/helphub-post-types/classes/class-helphub-post-types-post-type.php
+++ b/plugins/helphub-post-types/classes/class-helphub-post-types-post-type.php
@@ -398,7 +398,9 @@ class HelpHub_Post_Types_Post_Type {
 		global $post, $messages;
 
 		// Verify
-		if ( ( get_post_type() != $this->post_type ) || ! wp_verify_nonce( $_POST['helphub_' . $this->post_type . '_noonce'], plugin_basename( dirname( HelpHub_Post_Types()->plugin_path ) ) ) ) {
+		$plugin_basename = plugin_basename( dirname( HelpHub_Post_Types()->plugin_path ) );
+		$nonce_key = 'helphub_' . $this->post_type . '_noonce';
+		if ( empty( $_POST[ $nonce_key ] ) || ( get_post_type() != $this->post_type ) || ! wp_verify_nonce( $_POST[ $nonce_key ], $plugin_basename ) ) {
 			return $post_id;
 		}
 


### PR DESCRIPTION
```
Notice: Undefined index: helphub_post_noonce in /var/www/html/wp-content/plugins/helphub-post-types/classes/class-helphub-post-types-post-type.php on line 401
```

![](https://www.evernote.com/l/ABWdnEWTqGFOGaH10W7s8ZNrrhOjKZcWPZEB/image.png)

This notice is displayed for the first time only.