### PR TITLE
Update WordPress Coding Standards to use the `develop` branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_script:
   # Install CodeSniffer for WordPress Coding Standards checks.
   - mkdir php-codesniffer && curl -L https://github.com/squizlabs/PHP_CodeSniffer/archive/2.9.1.tar.gz  | tar xz --strip-components=1 -C php-codesniffer
   # Install WordPress Coding Standards.
-  - mkdir wordpress-coding-standards && curl -L https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/archive/master.tar.gz | tar xz --strip-components=1 -C wordpress-coding-standards
+  - mkdir wordpress-coding-standards && curl -L https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/archive/develop.tar.gz | tar xz --strip-components=1 -C wordpress-coding-standards
   # Hop into CodeSniffer directory.
   - cd php-codesniffer
   # Set install path for WordPress Coding Standards
@@ -70,13 +70,13 @@ script:
   # Search theme for PHP syntax errors.
   - find . \( -name '*.php' \) -exec php -lf {} \;
   # PHPCS WordPress Coding Standards
-  - ../php-codesniffer/scripts/phpcs -p -s -v -n . --standard=../phpcs.ruleset.xml --extensions=php
+  - ../php-codesniffer/scripts/phpcs -p -s -v -n . --standard=../phpcs.ruleset.xml
   # Change to the plugins folder
   - cd .. && cd plugins
   # Search theme for PHP syntax errors.
   - find . \( -name '*.php' \) -exec php -lf {} \;
   # PHPCS WordPress Coding Standards
-  - ../php-codesniffer/scripts/phpcs -p -s -v -n . --standard=../phpcs.ruleset.xml --extensions=php
+  - ../php-codesniffer/scripts/phpcs -p -s -v -n . --standard=../phpcs.ruleset.xml
   # Setup NodeJS version using NVM
   - node --version
   - npm --version

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress Coding Standards via https://github.com/Automattic/_s/blob/master/codesniffer.ruleset.xml">
-	<!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress-Core/ruleset.xml -->
+<ruleset name="WordPress Coding Standards">
+	<description>Apply WordPress Coding Standards to all HelpHub files.</description>
 
-	<!-- Set a description for this ruleset. -->
-	<description>A custom set of code standard rules to check for WordPress themes.</description>
+	<rule ref="WordPress-Core" />
+
+	<arg name="extensions" value="php" />
+
+	<!-- Show sniff codes in all reports -->
+	<arg value="s" />
+
+	<file>.</file>
 
 	<exclude-pattern>plugins/syntaxhighlighter/*</exclude-pattern>
 
-	<!-- Include the WordPress ruleset, with exclusions. -->
-	<rule ref="WordPress">
-		<exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
-		<exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
-		<exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
-	</rule>
 </ruleset>

--- a/plugins/helphub-post-types/classes/class-helphub-post-types-post-type.php
+++ b/plugins/helphub-post-types/classes/class-helphub-post-types-post-type.php
@@ -144,7 +144,9 @@ class HelpHub_Post_Types_Post_Type {
 			'show_ui' => true,
 			'show_in_menu' => true,
 			'query_var' => true,
-			'rewrite' => array( 'slug' => $single_slug ),
+			'rewrite' => array(
+				'slug' => $single_slug,
+			),
 			'capability_type' => 'post',
 			'has_archive' => $archive_slug,
 			'hierarchical' => false,
@@ -187,11 +189,11 @@ class HelpHub_Post_Types_Post_Type {
 		switch ( $column_name ) {
 			case 'image':
 				// Displays img tag.
-				echo $this->get_image( $id, 40 ); /* @codingStandardsIgnoreLine */
-			break;
+				echo $this->get_image( $id, 40 );
+				break;
 
 			default:
-			break;
+				break;
 		}
 	} // End register_custom_columns()
 
@@ -204,17 +206,22 @@ class HelpHub_Post_Types_Post_Type {
 	 * @return array $defaults
 	 */
 	public function register_custom_column_headings( $defaults ) {
-		$new_columns = array( 'image' => __( 'Image', 'helphub' ) );
+		$new_columns = array(
+			'image' => __( 'Image', 'helphub' ),
+		);
 
 		$last_item = array();
 
-		if ( isset( $defaults['date'] ) ) { unset( $defaults['date'] ); }
+		if ( isset( $defaults['date'] ) ) {
+			unset( $defaults['date'] );
+		}
 
 		if ( count( $defaults ) > 2 ) {
 			$last_item = array_slice( $defaults, -1 );
 
 			array_pop( $defaults );
 		}
+
 		$defaults = array_merge( $defaults, $new_columns );
 
 		if ( is_array( $last_item ) && 0 < count( $last_item ) ) {
@@ -246,13 +253,15 @@ class HelpHub_Post_Types_Post_Type {
 			3 => __( 'Custom field deleted.', 'helphub' ),
 			4 => sprintf( __( '%s updated.', 'helphub' ), $this->singular ),
 			/* translators: %s: date and time of the revision */
-			5 => isset( $_GET['revision'] ) ? sprintf( __( '%1$s restored to revision from %2$s', 'helphub' ), $this->singular, wp_post_revision_title( (int) $_GET['revision'], false ) ): false,
+			5 => isset( $_GET['revision'] ) ? sprintf( __( '%1$s restored to revision from %2$s', 'helphub' ), $this->singular, wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
 			6 => sprintf( __( '%1$s published. %3$sView %2$s%4$s', 'helphub' ), $this->singular, strtolower( $this->singular ), '<a href="' . esc_url( $permalink ) . '">', '</a>' ),
 			7 => sprintf( __( '%s saved.', 'helphub' ), $this->singular ),
 			8 => sprintf( __( '%1$s submitted. %2$sPreview %3$s%4$s', 'helphub' ), $this->singular, strtolower( $this->singular ), '<a target="_blank" href="' . esc_url( add_query_arg( 'preview', 'true', $permalink ) ) . '">', '</a>' ),
-			9 => sprintf( __( '%1$s scheduled for: %1$s. %2$sPreview %2$s%3$s', 'helphub' ), $this->singular, strtolower( $this->singular ),
-			// translators: Publish box date format, see http://php.net/date.
-			'<strong>' . date_i18n( __( 'M j, Y @ G:i', 'helphub' ), strtotime( $post->post_date ) ) . '</strong>', '<a target="_blank" href="' . esc_url( $permalink ) . '">', '</a>' ),
+			9 => sprintf(
+				__( '%1$s scheduled for: %1$s. %2$sPreview %2$s%3$s', 'helphub' ), $this->singular, strtolower( $this->singular ),
+				// translators: Publish box date format, see http://php.net/date.
+				'<strong>' . date_i18n( __( 'M j, Y @ G:i', 'helphub' ), strtotime( $post->post_date ) ) . '</strong>', '<a target="_blank" href="' . esc_url( $permalink ) . '">', '</a>'
+			),
 			10 => sprintf( __( '%1$s draft updated. %2$sPreview %3$s%4$s', 'helphub' ), $this->singular, strtolower( $this->singular ), '<a target="_blank" href="' . esc_url( add_query_arg( 'preview', 'true', $permalink ) ) . '">', '</a>' ),
 		);
 
@@ -352,7 +361,12 @@ class HelpHub_Post_Types_Post_Type {
 						break;
 					case 'editor':
 						ob_start();
-						wp_editor( $data, $k, array( 'media_buttons' => false, 'textarea_rows' => 10 ) );
+						wp_editor(
+							$data, $k, array(
+								'media_buttons' => false,
+								'textarea_rows' => 10,
+							)
+						);
 						$field = ob_get_contents();
 						ob_end_clean();
 						$html .= '<tr valign="top"><th scope="row"><label for="' . esc_attr( $k ) . '">' . $v['name'] . '</label></th><td>' . $field . "\n";
@@ -702,7 +716,9 @@ class HelpHub_Post_Types_Post_Type {
 	 * @since  1.0.0
 	 */
 	public function ensure_post_thumbnails_support() {
-		if ( ! current_theme_supports( 'post-thumbnails' ) ) { add_theme_support( 'post-thumbnails' ); }
+		if ( ! current_theme_supports( 'post-thumbnails' ) ) {
+			add_theme_support( 'post-thumbnails' );
+		}
 	} // End ensure_post_thumbnails_support()
 
 	/**

--- a/plugins/helphub-post-types/helphub-post-types.php
+++ b/plugins/helphub-post-types/helphub-post-types.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Returns the main instance of HelpHub_Post_Types to prevent the need to use globals.
  *
- * @since  1.0.0
+ * @since 1.0.0
  * @return object HelpHub_Post_Types
  */
 function helphub_post_types() {
@@ -38,54 +38,54 @@ add_action( 'plugins_loaded', 'helphub_post_types' );
  * Main HelpHub_Post_Types Class
  *
  * @class HelpHub_Post_Types
- * @version	1.0.0
+ * @version 1.0.0
  * @since 1.0.0
- * @package	HelpHub_Post_Types
+ * @package HelpHub_Post_Types
  * @author Jon Ang
  */
 final class HelpHub_Post_Types {
 	/**
 	 * HelpHub_Post_Types The single instance of HelpHub_Post_Types.
 	 *
-	 * @var 	object
-	 * @access  private
-	 * @since 	1.0.0
+	 * @var object
+	 * @access private
+	 * @since 1.0.0
 	 */
 	private static $_instance = null;
 
 	/**
 	 * The token.
 	 *
-	 * @var     string
-	 * @access  public
-	 * @since   1.0.0
+	 * @var string
+	 * @access public
+	 * @since 1.0.0
 	 */
 	public $token;
 
 	/**
 	 * The version number.
 	 *
-	 * @var     string
-	 * @access  public
-	 * @since   1.0.0
+	 * @var string
+	 * @access public
+	 * @since 1.0.0
 	 */
 	public $version;
 
 	/**
 	 * The plugin directory URL.
 	 *
-	 * @var     string
-	 * @access  public
-	 * @since   1.0.0
+	 * @var string
+	 * @access public
+	 * @since 1.0.0
 	 */
 	public $plugin_url;
 
 	/**
 	 * The plugin directory path.
 	 *
-	 * @var     string
-	 * @access  public
-	 * @since   1.0.0
+	 * @var string
+	 * @access public
+	 * @since 1.0.0
 	 */
 	public $plugin_path;
 
@@ -94,18 +94,18 @@ final class HelpHub_Post_Types {
 	/**
 	 * The admin object.
 	 *
-	 * @var     object
-	 * @access  public
-	 * @since   1.0.0
+	 * @var object
+	 * @access public
+	 * @since 1.0.0
 	 */
 	public $admin;
 
 	/**
 	 * The settings object.
 	 *
-	 * @var     object
-	 * @access  public
-	 * @since   1.0.0
+	 * @var object
+	 * @access public
+	 * @since 1.0.0
 	 */
 	public $settings;
 
@@ -116,9 +116,9 @@ final class HelpHub_Post_Types {
 	/**
 	 * The post types we're registering.
 	 *
-	 * @var     array
-	 * @access  public
-	 * @since   1.0.0
+	 * @var array
+	 * @access public
+	 * @since 1.0.0
 	 */
 	public $post_types = array();
 
@@ -129,9 +129,9 @@ final class HelpHub_Post_Types {
 	/**
 	 * The taxonomies we're registering.
 	 *
-	 * @var     array
-	 * @access  public
-	 * @since   1.0.0
+	 * @var array
+	 * @access public
+	 * @since 1.0.0
 	 */
 	public $taxonomies = array();
 
@@ -141,8 +141,8 @@ final class HelpHub_Post_Types {
 	/**
 	 * Constructor function.
 	 *
-	 * @access  public
-	 * @since   1.0.0
+	 * @access public
+	 * @since 1.0.0
 	 */
 	public function __construct() {
 		$this->token        = 'helphub';
@@ -151,13 +151,20 @@ final class HelpHub_Post_Types {
 		$this->version      = '1.0.0';
 
 		/* Post Types - Start */
-
 		require_once( 'classes/class-helphub-post-types-post-type.php' );
 		require_once( 'classes/class-helphub-post-types-taxonomy.php' );
 
 		// Register an example post type. To register other post types, duplicate this line.
-		$this->post_types['post'] = new HelpHub_Post_Types_Post_Type( 'post', __( 'Post', 'helphub' ), __( 'Posts', 'helphub' ), array( 'menu_icon' => 'dashicons-post' ) );
-		$this->post_types['helphub_version'] = new HelpHub_Post_Types_Post_Type( 'helphub_version', __( 'WordPress Version', 'helphub' ), __( 'WordPress Versions', 'helphub' ), array( 'menu_icon' => 'dashicons-wordpress' ) );
+		$this->post_types['post'] = new HelpHub_Post_Types_Post_Type(
+			'post', __( 'Post', 'helphub' ), __( 'Posts', 'helphub' ), array(
+				'menu_icon' => 'dashicons-post',
+			)
+		);
+		$this->post_types['helphub_version'] = new HelpHub_Post_Types_Post_Type(
+			'helphub_version', __( 'WordPress Version', 'helphub' ), __( 'WordPress Versions', 'helphub' ), array(
+				'menu_icon' => 'dashicons-wordpress',
+			)
+		);
 
 		/* Post Types - End */
 
@@ -193,8 +200,8 @@ final class HelpHub_Post_Types {
 	/**
 	 * Load the localisation file.
 	 *
-	 * @access  public
-	 * @since   1.0.0
+	 * @access public
+	 * @since 1.0.0
 	 */
 	public function load_plugin_textdomain() {
 		load_plugin_textdomain( 'helphub', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
@@ -204,8 +211,8 @@ final class HelpHub_Post_Types {
 	 * Enqueue post type admin Styles.
 	 *
 	 * @access public
-	 * @since   1.0.0
-	 * @return   void
+	 * @since 1.0.0
+	 * @return void
 	 */
 	public function enqueue_admin_styles() {
 		global $pagenow;
@@ -220,18 +227,20 @@ final class HelpHub_Post_Types {
 				wp_enqueue_style( 'jquery-ui-datepicker' );
 			endif;
 		endif;
-		wp_localize_script( 'helphub-post-types-admin', 'helphub_admin',
+		wp_localize_script(
+			'helphub-post-types-admin', 'helphub_admin',
 			array(
-				'default_title' 	=> __( 'Upload', 'helphub' ),
-				'default_button' 	=> __( 'Select this', 'helphub' ),
+				'default_title'     => __( 'Upload', 'helphub' ),
+				'default_button'    => __( 'Select this', 'helphub' ),
 			)
 		);
 
-		wp_localize_script( 'helphub-post-types-gallery', 'helphub_gallery',
+		wp_localize_script(
+			'helphub-post-types-gallery', 'helphub_gallery',
 			array(
-				'gallery_title' 	=> __( 'Add Images to Product Gallery', 'helphub' ),
-				'gallery_button' 	=> __( 'Add to gallery', 'helphub' ),
-				'delete_image'		=> __( 'Delete image', 'helphub' ),
+				'gallery_title'     => __( 'Add Images to Product Gallery', 'helphub' ),
+				'gallery_button'    => __( 'Add to gallery', 'helphub' ),
+				'delete_image'      => __( 'Delete image', 'helphub' ),
 			)
 		);
 
@@ -260,8 +269,8 @@ final class HelpHub_Post_Types {
 	/**
 	 * Installation. Runs on activation.
 	 *
-	 * @access  public
-	 * @since   1.0.0
+	 * @access public
+	 * @since 1.0.0
 	 */
 	public function install() {
 		$this->_log_version_number();
@@ -270,8 +279,8 @@ final class HelpHub_Post_Types {
 	/**
 	 * Log the plugin version number.
 	 *
-	 * @access  private
-	 * @since   1.0.0
+	 * @access private
+	 * @since 1.0.0
 	 */
 	private function _log_version_number() {
 		// Log the version number.

--- a/plugins/table-of-contents-lite/includes/class-table-of-contents-lite.php
+++ b/plugins/table-of-contents-lite/includes/class-table-of-contents-lite.php
@@ -26,81 +26,81 @@ class Table_Of_Contents_Lite {
 	/**
 	 * The single instance of Table_Of_Contents_Lite.
 	 *
-	 * @var 	object
-	 * @access  private
-	 * @since 	1.0.0
+	 * @var object
+	 * @access private
+	 * @since 1.0.0
 	 */
 	private static $_instance = null;
 
 	/**
 	 * Settings class object
 	 *
-	 * @var     object
-	 * @access  public
-	 * @since   1.0.0
+	 * @var object
+	 * @access public
+	 * @since 1.0.0
 	 */
 	public $settings = null;
 
 	/**
 	 * The version number.
 	 *
-	 * @var     string
-	 * @access  public
-	 * @since   1.0.0
+	 * @var string
+	 * @access public
+	 * @since 1.0.0
 	 */
 	public $_version;
 
 	/**
 	 * The token.
 	 *
-	 * @var     string
-	 * @access  public
-	 * @since   1.0.0
+	 * @var string
+	 * @access public
+	 * @since 1.0.0
 	 */
 	public $_token;
 
 	/**
 	 * The main plugin file.
 	 *
-	 * @var     string
-	 * @access  public
-	 * @since   1.0.0
+	 * @var string
+	 * @access public
+	 * @since 1.0.0
 	 */
 	public $file;
 
 	/**
 	 * The main plugin directory.
 	 *
-	 * @var     string
-	 * @access  public
-	 * @since   1.0.0
+	 * @var string
+	 * @access public
+	 * @since 1.0.0
 	 */
 	public $dir;
 
 	/**
 	 * The plugin assets directory.
 	 *
-	 * @var     string
-	 * @access  public
-	 * @since   1.0.0
+	 * @var string
+	 * @access public
+	 * @since 1.0.0
 	 */
 	public $assets_dir;
 
 	/**
 	 * The plugin assets URL.
 	 *
-	 * @var     string
-	 * @access  public
-	 * @since   1.0.0
+	 * @var string
+	 * @access public
+	 * @since 1.0.0
 	 */
 	public $assets_url;
 
 	/**
 	 * Suffix for Javascripts.
 	 *
-	 * @var     string
-	 * @access  public
-	 * @since   1.0.0
+	 * @var string
+	 * @access public
+	 * @since 1.0.0
 	 */
 	public $script_suffix;
 
@@ -108,10 +108,10 @@ class Table_Of_Contents_Lite {
 	 * Constructor function.
 	 *
 	 * @access public
-	 * @param	string $file filename of the plugin.
-	 * @param	string $version version number of plugin.
-	 * @since   1.0.0
-	 * @return  void
+	 * @param string $file filename of the plugin.
+	 * @param string $version version number of plugin.
+	 * @since 1.0.0
+	 * @return void
 	 */
 	public function __construct( $file = '', $version = '1.0.0' ) {
 		$this->_version = $version;
@@ -135,8 +135,8 @@ class Table_Of_Contents_Lite {
 	/**
 	 * Load plugin initialization
 	 *
-	 * @access  public
-	 * @since   1.0.0
+	 * @access public
+	 * @since 1.0.0
 	 * @return  void
 	 */
 	public function plugin_init() {
@@ -149,10 +149,10 @@ class Table_Of_Contents_Lite {
 	 *
 	 * @since 1.0.0
 	 * @static
-	 * @param	string $file filename of the plugin.
-	 * @param	string $version version number of plugin.
-	 * @see	Table_Of_Contents_Lite()
-	 * @return	Main Table_Of_Contents_Lite instance
+	 * @param string $file filename of the plugin.
+	 * @param string $version version number of plugin.
+	 * @see Table_Of_Contents_Lite()
+	 * @return  Main Table_Of_Contents_Lite instance
 	 */
 	public static function instance( $file = '', $version = '1.0.0' ) {
 		if ( is_null( self::$_instance ) ) {
@@ -182,8 +182,8 @@ class Table_Of_Contents_Lite {
 	/**
 	 * Installation. Runs on activation.
 	 *
-	 * @access  public
-	 * @since   1.0.0
+	 * @access public
+	 * @since 1.0.0
 	 * @return  void
 	 */
 	public function install() {
@@ -193,8 +193,8 @@ class Table_Of_Contents_Lite {
 	/**
 	 * Log the plugin version number.
 	 *
-	 * @access  public
-	 * @since   1.0.0
+	 * @access public
+	 * @since 1.0.0
 	 * @return  void
 	 */
 	private function _log_version_number() {
@@ -204,8 +204,8 @@ class Table_Of_Contents_Lite {
 	/**
 	 * Main function that adds the TOC to the regular content of each post.
 	 *
-	 * @param	longtext $content contains the post content.
-	 * @return	longtext generatod TOC based from the h tags in the $content plus the $content at the end.
+	 * @param longtext $content contains the post content.
+	 * @return  longtext generatod TOC based from the h tags in the $content plus the $content at the end.
 	 */
 	public function add_toc( $content ) {
 
@@ -245,9 +245,9 @@ class Table_Of_Contents_Lite {
 	/**
 	 * Filters all header tags in the current content.
 	 *
-	 * @param	string $tag header tags to be included, default h1-h4.
-	 * @param	string $content	content to be filtered.
-	 * @return	array $matches all filtered header tags.
+	 * @param string $tag header tags to be included, default h1-h4.
+	 * @param string $content content to be filtered.
+	 * @return  array $matches all filtered header tags.
 	 */
 	public function get_tags_in_content( $tag, $content = '' ) {
 		if ( empty( $content ) ) {
@@ -262,7 +262,7 @@ class Table_Of_Contents_Lite {
 	 *
 	 * @param string   $tag    depending on the tag, it will place the TOC link deeper in the ul - li tag.
 	 * @param longtext $content    content to be filtered.
-	 * @return array $content	returns the content with the partial TOC on top.
+	 * @return array $content   returns the content with the partial TOC on top.
 	 */
 	public function add_ids_and_jumpto_links( $tag, $content ) {
 		$items = $this->get_tags_in_content( $tag, $content );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,15 +22,23 @@ function _manually_load_theme_and_plugin() {
 
 	register_theme_directory( dirname( $theme_dir ) );
 
-	add_filter( 'pre_option_template', function() use ( $current_theme ) {
-		return $current_theme;
-	} );
-	add_filter( 'pre_option_stylesheet', function() use ( $current_theme ) {
-		return $current_theme;
-	} );
-	add_filter( 'template_directory', function() use ( $theme_dir ) {
-		return $theme_dir;
-	} );
+	add_filter(
+		'pre_option_template', function() use ( $current_theme ) {
+			return $current_theme;
+		}
+	);
+
+	add_filter(
+		'pre_option_stylesheet', function() use ( $current_theme ) {
+			return $current_theme;
+		}
+	);
+
+	add_filter(
+		'template_directory', function() use ( $theme_dir ) {
+			return $theme_dir;
+		}
+	);
 
 	require dirname( dirname( __FILE__ ) ) . '/plugins/helphub-post-types/helphub-post-types.php';
 	require dirname( dirname( __FILE__ ) ) . '/plugins/helphub-read-time/helphub-read-time.php';

--- a/tests/test-helphub-post-type.php
+++ b/tests/test-helphub-post-type.php
@@ -98,7 +98,7 @@ class Helphub_Post_Type_Test extends WP_UnitTestCase {
 				'default' => '',
 				'section' => 'info',
 				'label' => 'this is as label for textarea',
-			)
+			),
 		);
 		$html = $this->meta_box_content_render( $fields );
 		$this->assertContains( '<textarea name="textarea-field" id="textarea-field" class="large-text"></textarea>', $html );
@@ -120,7 +120,7 @@ class Helphub_Post_Type_Test extends WP_UnitTestCase {
 				'default' => '',
 				'section' => 'info',
 				'label' => 'this is as label for editor',
-			)
+			),
 		);
 		$html = $this->meta_box_content_render( $fields );
 		$this->assertContains( '<div id="wp-editor-field-wrap" class="wp-core-ui wp-editor-wrap html-active"><div id="wp-editor-field-editor-container" class="wp-editor-container"><div id="qt_editor-field_toolbar" class="quicktags-toolbar"></div><textarea class="wp-editor-area" rows="10" cols="40" name="editor-field" id="editor-field"></textarea></div>', $html );
@@ -142,7 +142,7 @@ class Helphub_Post_Type_Test extends WP_UnitTestCase {
 				'default' => '',
 				'section' => 'info',
 				'label' => 'this is as label for upload',
-			)
+			),
 		);
 		$html = $this->meta_box_content_render( $fields );
 		$this->assertContains( '<input name="upload-field" type="file" id="upload-field" class="regular-text helphub-upload-field" /><button id="upload-field" class="helphub-upload button">this is as label for upload</button>', $html );
@@ -164,7 +164,7 @@ class Helphub_Post_Type_Test extends WP_UnitTestCase {
 					'miya' => 'cool',
 					'jon' => 'very cool',
 				),
-			)
+			),
 		);
 		$html = $this->meta_box_content_render( $fields );
 		$this->assertContains( '<p><label for="radio-field-miya"><input id="radio-field-miya" type="radio" name="radio-field" value="miya"  />cool</label></p>', $html );
@@ -192,7 +192,7 @@ class Helphub_Post_Type_Test extends WP_UnitTestCase {
 					'miya' => 'cool',
 					'jon' => 'very cool',
 				),
-			)
+			),
 		);
 		$html = $this->meta_box_content_render( $fields );
 		$this->assertContains( '<p><label for="multicheck-field-miya"><input id="multicheck-field-miya" type="checkbox" name="multicheck-field[]" value="miya"  />cool</label></p>', $html );
@@ -220,7 +220,7 @@ class Helphub_Post_Type_Test extends WP_UnitTestCase {
 					'miya' => 'cool',
 					'jon' => 'very cool',
 				),
-			)
+			),
 		);
 		$html = $this->meta_box_content_render( $fields );
 		$this->assertContains( '<select name="select-field" id="select-field" ><option value="miya" >cool</option><option value="jon" >very cool</option></select>', $html );
@@ -242,7 +242,7 @@ class Helphub_Post_Type_Test extends WP_UnitTestCase {
 				'default' => '',
 				'section' => 'info',
 				'label' => 'this is as label for date',
-			)
+			),
 		);
 		$html = $this->meta_box_content_render( $fields );
 		$this->assertContains( '<input name="date-field" type="date" id="date-field" class="helphub-meta-date" value="' . esc_attr( date_i18n( 'F d, Y', time() ) ) . '" />', $html );
@@ -263,7 +263,9 @@ class Helphub_Post_Type_Test extends WP_UnitTestCase {
 			'post',
 			__( 'Post', 'helphub' ),
 			__( 'Posts', 'helphub' ),
-			array( 'menu_icon' => 'dashicons-post' )
+			array(
+				'menu_icon' => 'dashicons-post',
+			)
 		);
 
 		ob_start();

--- a/tests/test-helphub-read-time.php
+++ b/tests/test-helphub-read-time.php
@@ -14,30 +14,44 @@ class Helphub_Read_Time_Test extends WP_UnitTestCase {
 	 * @covers hh_calculate_and_update_post_read_time
 	 */
 	public function test_hh_calculate_and_update_post_read_time() {
-		$user = $this->factory->user->create( array(
-			'role' => 'administrator',
-		) );
+		$user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
 
 		wp_set_current_user( $user );
 
 		// 175 words.
 		$lorem_ipsum_for_minute = 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget';
 
-		$post = $this->factory->post->create_and_get( array( 'post_content' => $lorem_ipsum_for_minute ) );
+		$post = $this->factory->post->create_and_get(
+			array(
+				'post_content' => $lorem_ipsum_for_minute,
+			)
+		);
 		hh_calculate_and_update_post_read_time( $post->ID, $post, false );
 		$this->assertContains( '_read_time', get_post_custom_keys( $post->ID ) );
 		$read_time = get_post_meta( $post->ID, '_read_time', true );
 		$this->assertEquals( 60, $read_time );
 
 		// Test for <pre>.
-		$post_with_pretag = $this->factory->post->create_and_get( array( 'post_content' => '<pre>' . $lorem_ipsum_for_minute . '</pre>' ) );
+		$post_with_pretag = $this->factory->post->create_and_get(
+			array(
+				'post_content' => '<pre>' . $lorem_ipsum_for_minute . '</pre>',
+			)
+		);
 		hh_calculate_and_update_post_read_time( $post_with_pretag->ID, $post_with_pretag, false );
 		$this->assertContains( '_read_time', get_post_custom_keys( $post_with_pretag->ID ) );
 		$read_time = get_post_meta( $post_with_pretag->ID, '_read_time', true );
 		$this->assertEquals( 120, $read_time );
 
 		// Test for <img>.
-		$post_with_img = $this->factory->post->create_and_get( array( 'post_content' => '<img src="dummy.png" />' ) );
+		$post_with_img = $this->factory->post->create_and_get(
+			array(
+				'post_content' => '<img src="dummy.png" />',
+			)
+		);
 		hh_calculate_and_update_post_read_time( $post_with_img->ID, $post_with_img, false );
 		$this->assertContains( '_read_time', get_post_custom_keys( $post_with_img->ID ) );
 		$read_time = get_post_meta( $post_with_img->ID, '_read_time', true );


### PR DESCRIPTION
This updates WPCS to use the _develop_ branch:

See also: https://core.trac.wordpress.org/ticket/41057

It's based on the latest patch in #WP41057: [phpcs.xml.4.dist](https://core.trac.wordpress.org/attachment/ticket/41057/phpcs.xml.4.dist)