### PR TITLE
Switch Travis CI to Trusty distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ php:
 # @link https://docs.travis-ci.com/user/ci-environment/
 sudo: false
 
+# Tell Travis CI which distro to use
+dist: trusty
+ 
 # Travis CI environment matrix
 env:
   matrix:


### PR DESCRIPTION
Travis CI have announced they are switching to Trusty as the default distro come July 18th 2017
> https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming

