### PR TITLE
Remove `--force` option from `grunt` command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,6 @@ script:
   - npm install
   - npm install -g grunt-cli
   # Run CSS, JS, & PHP Grunt tasks (Temporarily using --force so all tasks run)
-  - grunt --force
+  - grunt
   # PHPUnit
   - cd .. && phpunit


### PR DESCRIPTION
Previously the `--force` command was used to _force_ etc Grunt task to run irrespective of any failures of running Grunt tasks, this should now be removed.