### PR TITLE
Ignore the WordPress Importer plugin and php.ini 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 node_modules/
 wordpress-coding-standards
 php-codesniffer
+plugins/wordpress-importer/
+php.ini

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ node_modules/
 wordpress-coding-standards
 php-codesniffer
 plugins/wordpress-importer/
-php.ini


### PR DESCRIPTION
Since they are used for replicating the local environment but don't need to be included with the whole Repo.