### PR TITLE
Remove duplicate sidebar calls and duplicate wrappers

### DIFF
--- a/themes/helphub/archive.php
+++ b/themes/helphub/archive.php
@@ -46,5 +46,4 @@ get_header(); ?>
 	</div><!-- #primary -->
 
 <?php
-get_sidebar();
 get_footer();

--- a/themes/helphub/header.php
+++ b/themes/helphub/header.php
@@ -47,8 +47,4 @@
 	</header><!-- #masthead -->
 	<div id="page" class="hfeed site">
 		<div id="main" class="site-main clear">
-			<div id="secondary" class="widget-area" role="complementary">
-				<div id="secondary-content">
-					<?php get_sidebar(); ?>
-				</div>
-			</div>
+			<?php get_sidebar(); ?>

--- a/themes/helphub/search.php
+++ b/themes/helphub/search.php
@@ -50,5 +50,4 @@ get_header(); ?>
 	</section><!-- #primary -->
 
 <?php
-get_sidebar();
 get_footer();

--- a/themes/helphub/sidebar.php
+++ b/themes/helphub/sidebar.php
@@ -13,7 +13,7 @@ if ( ( ! is_active_sidebar( 'sidebar-1' ) ) || is_front_page() ) {
 ?>
 
 <aside id="secondary" class="widget-area" role="complementary">
-	<?php
-		dynamic_sidebar( 'sidebar-1' );
-	?>
+	<div id="secondary-content">
+		<?php dynamic_sidebar( 'sidebar-1' ); ?>
+	</div>
 </aside><!-- #secondary -->


### PR DESCRIPTION
The sidebars were getting called in some template files when they should only be called once by the header file.

There was also some duplicate markup ids being used, so cleaned that a bit as well.