### PR TITLE
Include Node.js' `- $HOME/.npm` in Travis CI cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
 # Setup NPM modules for Travis CI cache maintanence.
 cache:
   directories:
+    - $HOME/.npm
     - node_modules
     - vendor
     - $HOME/.composer/cache


### PR DESCRIPTION
This change ensures Node.js binaries are included in the cache for faster CI jobs