### PR TITLE
Added `word-wrap: break-word` to body

### DIFF
--- a/themes/helphub/sass/elements/_elements.scss
+++ b/themes/helphub/sass/elements/_elements.scss
@@ -4,6 +4,9 @@ html {
 
 body {
 	background: $color__background-body; /* Fallback for when there is no custom background color defined. */
+	word-wrap: break-word; /* old IE */
+	overflow-wrap: break-word; /* modern synonym for word-wrap */
+	word-break: keep-all; /* affects some Asian languages */
 }
 
 blockquote,


### PR DESCRIPTION
Just added `word-wrap: break-word` to body, so that the body will not be longer than device's width even if long codes are there.