### PR TITLE
Unify Archives font and layout with Post/Pages

### DIFF
--- a/themes/helphub/sass/site/primary/_posts-and-pages.scss
+++ b/themes/helphub/sass/site/primary/_posts-and-pages.scss
@@ -21,7 +21,7 @@
 	margin: 0 0 1.5em;
 }
 
-.single-post {
+.single-handbook {
 
 	h1 {
 

--- a/themes/helphub/sass/typography/_typography.scss
+++ b/themes/helphub/sass/typography/_typography.scss
@@ -1,5 +1,5 @@
 body,
-body.single-post,
+body.single-handbook,
 button,
 input,
 select,


### PR DESCRIPTION
For Isssue #126 Archives, as an first steps, I would like to adjust font & layout of Archives as like as Post/Page's ones.
In each Post/Page, those are specified with 'single-post' in site/primary/_posts-and-pages.scss and typography/_typography.scss.

`<body class="post-template-default single single-post postid-2004 single-format-standard single-handbook make-docs" id="wordpress-org">`

But archives contents are not enclosed by 'single-post'.

`<body class="archive category category-advanced-topics category-10 single-handbook make-docs group-blog hfeed" id="wordpress-org">`

I believe we can change 'single-post' to 'single-handbook'. Please refer the PR #xx

Notice: master's style.css seems to be different from Grunt result. 'git diff' reports differences between original style.css and the result of 'grunt sass'. So, I didn't include style.css in this PR.

Archive before fix: 
![archive-layout-before-fix](https://user-images.githubusercontent.com/8876600/32686242-abe76c16-c6e4-11e7-9eb9-9766b73ccaa4.jpg)

Archive after fix:
![archive-layout-after-fix](https://user-images.githubusercontent.com/8876600/32686249-b1d6e958-c6e4-11e7-880b-b0382a710e68.jpg)

