### PR TITLE
Add a link-block widget for use on the front page

### DIFF
--- a/plugins/support-helphub/inc/helphub-front-page-blocks/helphub-front-page-blocks.php
+++ b/plugins/support-helphub/inc/helphub-front-page-blocks/helphub-front-page-blocks.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Plugin Name: Helphub Front Page Blocks
+ * Plugin URI: https://www.wordpress.org
+ * Description: Create linkable blocks on the front page of support pages.
+ *
+ * @package HelpHub
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+require_once( dirname( __FILE__ ) . '/includes/class-support_helphub_front_page_blocks_widget.php' );
+
+function helphub_register_front_page_blocks_widget() {
+	register_widget( 'Support_HelpHub_Front_Page_blocks_Widget' );
+}
+add_action( 'widgets_init', 'helphub_register_front_page_blocks_widget' );

--- a/plugins/support-helphub/inc/helphub-front-page-blocks/helphub-front-page-blocks.php
+++ b/plugins/support-helphub/inc/helphub-front-page-blocks/helphub-front-page-blocks.php
@@ -11,9 +11,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-require_once( dirname( __FILE__ ) . '/includes/class-support_helphub_front_page_blocks_widget.php' );
+require_once( dirname( __FILE__ ) . '/includes/class-support-helphub-front-page-blocks-widget.php' );
 
 function helphub_register_front_page_blocks_widget() {
-	register_widget( 'Support_HelpHub_Front_Page_blocks_Widget' );
+	register_widget( 'Support_HelpHub_Front_Page_Blocks_Widget' );
 }
 add_action( 'widgets_init', 'helphub_register_front_page_blocks_widget' );

--- a/plugins/support-helphub/inc/helphub-front-page-blocks/includes/class-support-helphub-front-page-blocks-widget.php
+++ b/plugins/support-helphub/inc/helphub-front-page-blocks/includes/class-support-helphub-front-page-blocks-widget.php
@@ -9,7 +9,7 @@
 /**
  * Class Support_HelpHub_Front_Page_blocks_Widget
  */
-class Support_HelpHub_Front_Page_blocks_Widget extends WP_Widget {
+class Support_HelpHub_Front_Page_Blocks_Widget extends WP_Widget {
 	public function __construct() {
 		$widget_options = array(
 			'classname'   => 'helphub-front-page-block',

--- a/plugins/support-helphub/inc/helphub-front-page-blocks/includes/class-support_helphub_front_page_blocks_widget.php
+++ b/plugins/support-helphub/inc/helphub-front-page-blocks/includes/class-support_helphub_front_page_blocks_widget.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Marius
+ * Date: 21.02.2018
+ * Time: 23:40
+ */
+
+/**
+ * Class Support_HelpHub_Front_Page_blocks_Widget
+ */
+class Support_HelpHub_Front_Page_blocks_Widget extends WP_Widget {
+	public function __construct() {
+		$widget_options = array(
+			'classname'   => 'helphub-front-page-block',
+			'description' => __( 'Add a link block to support pages', 'wporg-forums' ),
+		);
+
+		parent::__construct( 'helphub_front_page_block', __( '(HelpHub) Link block', 'wporg-forums' ), $widget_options );
+	}
+
+	/**
+	 * Output the widget on the front end.
+	 *
+	 * @param array $args     The widget arguments, passed on from the themes widget area.
+	 * @param array $instance This individual widgets settings.
+	 *
+	 * @return void
+	 */
+	public function widget( $args, $instance ) {
+		include( dirname( __FILE__ ) . '/widget-front-end.php' );
+	}
+
+	/**
+	 * Generate the widget settings.
+	 *
+	 * @param array $instance The widget instance and arguments.
+	 *
+	 * @return void
+	 */
+	public function form( $instance ) {
+		include( dirname( __FILE__ ) . '/widget-back-end.php' );
+	}
+
+	/**
+	 * Save the widget settings from the admin.
+	 *
+	 * @param array $new_instance The old widget instance, for comparison.
+	 * @param array $old_instance The new widget instance, to be saved.
+	 *
+	 * @return array
+	 */
+	public function update( $new_instance, $old_instance ) {
+		$save_instance = array();
+
+		$save_instance['icon']  = ( ! empty( $new_instance['icon'] ) ? strip_tags( $new_instance['icon'] ) : '' );
+		$save_instance['title'] = ( ! empty( $new_instance['title'] ) ? strip_tags( $new_instance['title'] ) : '' );
+		$save_instance['description'] = ( ! empty( $new_instance['description'] ) ? strip_tags( $new_instance['description'] ) : '' );
+		$save_instance['menu'] = ( ! empty( $new_instance['menu'] ) ? strip_tags( $new_instance['menu'] ) : '' );
+
+		return $save_instance;
+	}
+}

--- a/plugins/support-helphub/inc/helphub-front-page-blocks/includes/widget-back-end.php
+++ b/plugins/support-helphub/inc/helphub-front-page-blocks/includes/widget-back-end.php
@@ -36,7 +36,7 @@
 		<?php
 		$nav_menus = wp_get_nav_menus();
 
-		foreach( $nav_menus as $nav_menu ) {
+		foreach ( $nav_menus as $nav_menu ) {
 			printf(
 				'<option value="%s" %s>%s</option>',
 				esc_attr( $nav_menu->term_id ),

--- a/plugins/support-helphub/inc/helphub-front-page-blocks/includes/widget-back-end.php
+++ b/plugins/support-helphub/inc/helphub-front-page-blocks/includes/widget-back-end.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Back-end output for the widget.
+ *
+ * @package HelpHub
+ */
+
+?>
+
+<p>
+	<label for="<?php echo esc_attr( $this->get_field_id( 'icon' ) ); ?>">
+		<?php esc_html_e( 'icon (dashicon name)', 'wporg-forums' ); ?>
+	</label>
+	<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'icon' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'icon' ) ); ?>" type="text" value="<?php echo ( isset( $instance['icon'] ) && ! empty( $instance['icon'] ) ? esc_attr( $instance['icon'] ) : '' ); ?>">
+</p>
+
+<p>
+	<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>">
+		<?php esc_html_e( 'Title', 'wporg-forums' ); ?>
+	</label>
+	<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo ( isset( $instance['title'] ) && ! empty( $instance['title'] ) ? esc_attr( $instance['title'] ) : esc_attr__( 'Title', 'wporg-forums' ) ); ?>">
+</p>
+
+<p>
+	<label for="<?php echo esc_attr( $this->get_field_id( 'description' ) ); ?>">
+		<?php esc_html_e( 'Description', 'wporg-forums' ); ?>
+	</label>
+	<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'description' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'description' ) ); ?>" type="text" value="<?php echo ( isset( $instance['description'] ) && ! empty( $instance['description'] ) ? esc_attr( $instance['description'] ) : esc_attr__( 'Block description', 'wporg-forums' ) ); ?>">
+</p>
+
+<p>
+	<label for="<?php echo esc_attr( $this->get_field_id( 'menu' ) ); ?>">
+		<?php esc_html_e( 'Link menu', 'wporg-forums' ); ?>
+	</label>
+	<select class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'menu' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'menu' ) ); ?>">
+		<?php
+		$nav_menus = wp_get_nav_menus();
+
+		foreach( $nav_menus as $nav_menu ) {
+			printf(
+				'<option value="%s" %s>%s</option>',
+				esc_attr( $nav_menu->term_id ),
+				( isset( $instance['menu'] ) && ! empty( $instance['menu'] ) && $nav_menu->term_id === $instance['menu'] ? 'selected="selected"' : '' ),
+				esc_html( $nav_menu->name )
+			);
+		}
+		?>
+	</select>
+</p>

--- a/plugins/support-helphub/inc/helphub-front-page-blocks/includes/widget-front-end.php
+++ b/plugins/support-helphub/inc/helphub-front-page-blocks/includes/widget-front-end.php
@@ -20,7 +20,7 @@ echo $args['before_widget']; // WPCS: XSS OK.
 	<ul class="meta-list">
 		<?php
 		$menu_items = wp_get_nav_menu_items( $instance['menu'] );
-		foreach( $menu_items as $menu_item ) {
+		foreach ( $menu_items as $menu_item ) {
 			printf(
 				'<li><a href="%s">%s</a></li>',
 				esc_url( $menu_item->url ),

--- a/plugins/support-helphub/inc/helphub-front-page-blocks/includes/widget-front-end.php
+++ b/plugins/support-helphub/inc/helphub-front-page-blocks/includes/widget-front-end.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Front-end output for the widget.
+ *
+ * @package HelpHub
+ */
+
+?>
+<?php
+echo $args['before_widget']; // WPCS: XSS OK.
+?>
+
+<div class="info-box">
+	<span class="dashicons
+	<?php echo esc_attr( $instance['icon'] ); ?>
+	"></span>
+	<h3><?php echo esc_html( $instance['title'] ); ?></h3>
+	<p><?php echo esc_html( $instance['description'] ); ?></p>
+
+	<ul class="meta-list">
+		<?php
+		$menu_items = wp_get_nav_menu_items( $instance['menu'] );
+		foreach( $menu_items as $menu_item ) {
+			printf(
+				'<li><a href="%s">%s</a></li>',
+				esc_url( $menu_item->url ),
+				esc_html( $menu_item->title )
+			);
+		}
+		?>
+	</ul>
+
+</div>
+
+
+<?php
+echo $args['after_widget']; // WPCS: XSS OK.

--- a/plugins/support-helphub/support-helphub.php
+++ b/plugins/support-helphub/support-helphub.php
@@ -19,3 +19,4 @@ require_once( dirname( __FILE__ ) . '/inc/helphub-post-types/helphub-post-types.
 require_once( dirname( __FILE__ ) . '/inc/helphub-read-time/helphub-read-time.php' );
 require_once( dirname( __FILE__ ) . '/inc/syntaxhighlighter/syntaxhighlighter.php' );
 require_once( dirname( __FILE__ ) . '/inc/table-of-contents-lite/table-of-contents-lite.php' );
+require_once( dirname( __FILE__ ) . '/inc/helphub-front-page-blocks/helphub-front-page-blocks.php' );


### PR DESCRIPTION
Introduces a new widget that lets users easily define blocks with links for use on the front page. This lets rosetta sites create their own blocks if desired as well, and gives us more flexibility without locking things in with anything hard coded.