### PR TITLE
Support Theme: Updates the support-theme with recent meta changesets

### DIFF
--- a/themes/wporg-support/functions.php
+++ b/themes/wporg-support/functions.php
@@ -36,7 +36,7 @@ function wporg_support_scripts() {
 	wp_enqueue_style( 'wp4', '//s.w.org/style/wp4.css?73' );
 	wp_enqueue_style( 'google-fonts', '//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,400,300,600&subset=latin,cyrillic-ext,greek-ext,greek,vietnamese,latin-ext,cyrillic' );
 
-	wp_enqueue_style( 'forum-wp4-style', get_stylesheet_uri(), [], '20180310' );
+	wp_enqueue_style( 'forum-wp4-style', get_stylesheet_uri(), [], '20180713' );
 	wp_style_add_data( 'forum-wp4-style', 'rtl', 'replace' );
 
 	wp_enqueue_script( 'wporg-support-navigation', get_template_directory_uri() . '/js/navigation.js', array(), '20151217', true );
@@ -201,7 +201,7 @@ add_filter( 'excerpt_length', 'wporg_support_excerpt_length' );
  * @package WPBBP
  */
 function wporg_get_global_header() {
-	$GLOBALS['pagetitle'] = wp_title( '&laquo;', false, 'right' ) . ' ' . get_bloginfo( 'name' );
+	$GLOBALS['pagetitle'] = wp_title( '&#124;', false, 'right' ) . ' ' . __( 'WordPress.org', 'wporg-forums' );
 	require WPORGPATH . 'header.php';
 }
 
@@ -213,6 +213,21 @@ function wporg_get_global_header() {
 function wporg_get_global_footer() {
 	require WPORGPATH . 'footer.php';
 }
+
+/**
+ * Append an optimized site name.
+ *
+ * @param array $title Parts of the page title.
+ * @return array Filtered title parts.
+ */
+function wporg_support_document_title( $title ) {
+	if ( is_front_page() ) {
+		$title[1] = _x( 'Support', 'Site title', 'wporg-forums' );
+	}
+
+	return $title;
+}
+add_filter( 'wp_title_parts', 'wporg_support_document_title' );
 
 /**
  * Link user profiles to their global profiles.

--- a/themes/wporg-support/header.php
+++ b/themes/wporg-support/header.php
@@ -32,12 +32,12 @@ if ( stristr( WPORGPATH, 'http' ) ) {
 		<header id="masthead" class="site-header <?php echo is_front_page() ? 'home' : ''; ?>" role="banner">
 			<div class="site-branding">
 				<?php if ( is_front_page() ) : ?>
-					<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php _ex( 'Support', 'Site title', 'wporg-forums' ); ?></a></h1>
+					<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php _ex( 'WordPress Support', 'Site title', 'wporg-forums' ); ?></a></h1>
 
 					<p class="site-description">
 						<?php
 						/* Translators: subhead */
-						_e( 'Explore a variety of resources to help you gain the most out of WordPress.', 'wporg-forums' );
+						_e( 'We&#8217;ve got a variety of resources to help you gain the most out of WordPress.', 'wporg-forums' );
 						?>
 					</p>
 					<?php get_search_form(); ?>

--- a/themes/wporg-support/page-homepage.php
+++ b/themes/wporg-support/page-homepage.php
@@ -1,11 +1,17 @@
 <?php
-
 /**
  * Template Name: bbPress - Support (Index)
  *
  * @package bbPress
  * @subpackage Theme
  */
+
+/**
+ * Adds a custom description meta tag.
+ */
+add_action( 'wp_head', function() {
+	printf( '<meta name="description" content="%s" />' . "\n", esc_attr__( 'Our community support articles are the best place to get the most out of WordPress. Learn how to set up your website, troubleshoot problems, customize your site, and more.', 'wporg-forums' ) );
+} );
 
 get_header(); ?>
 

--- a/themes/wporg-support/sass/site/_bbpress.scss
+++ b/themes/wporg-support/sass/site/_bbpress.scss
@@ -422,6 +422,19 @@ section {
 			color: #f00;
 		}
 
+		.create-topic {
+			font-size: 0.8rem;
+			float: left;
+
+			&:before {
+				color: #000;
+				content: "\f132";
+				font: 400 16px/1 dashicons;
+				margin: 0 4px 0 -4px;
+				vertical-align: middle;
+			}
+		}
+
 		.bbp-pagination {
 			font-size: ms(-2);
 			float: none;


### PR DESCRIPTION
Support Theme: Updates the support-theme with recent meta changesets 7455, 7453, 7452, 7450, 7289, and 7288

See [Diff [7256:7455] - sites/trunk/wordpress.org/public_html/wp-content/themes/pub/wporg-support](https://meta.trac.wordpress.org/changeset?sfp_email=&sfph_mail=&reponame=&new=7455%40sites%2Ftrunk%2Fwordpress.org%2Fpublic_html%2Fwp-content%2Fthemes%2Fpub%2Fwporg-support&old=7256%40sites%2Ftrunk%2Fwordpress.org%2Fpublic_html%2Fwp-content%2Fthemes%2Fpub%2Fwporg-support&sfp_email=&sfph_mail=)