### PR TITLE
Docs: Remove broken Travis CI badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HelpHub
 
-[![Build Status](https://travis-ci.com/WordPress/HelpHub.svg?branch=master)](https://travis-ci.com/WordPress/HelpHub)
+![Build Status](https://travis-ci.org/WordPress/HelpHub.svg?branch=master)
 
 
 HelpHub is going to be the new portal for all WordPress user documentation that currently resides on the [WordPress Codex](https://codex.wordpress.org/). This repo is where we will be managing the development of this new portal.


### PR DESCRIPTION
This PR removes the outdated and broken Travis CI badge from the README file.

The Travis CI service is no longer active for this project, and the linked badge currently returns a 404 error, resulting in a broken image. Removing the badge improves readability and avoids confusion for new contributors.

No other content has been modified.